### PR TITLE
Indexing speedup

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.2"
+__version__ = "2.0.3"
 
 __description__ = "meshiphi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"

--- a/meshiphi/dataloaders/lut/abstract_lut.py
+++ b/meshiphi/dataloaders/lut/abstract_lut.py
@@ -257,7 +257,7 @@ class LutDataLoader(DataLoaderInterface):
             
         return data
     
-    def get_value(self, bounds, agg_type=None, skipna=False):
+    def get_value(self, bounds, agg_type=None, skipna=False, data=None):
         '''
         Retrieve aggregated value from within bounds
         
@@ -277,7 +277,7 @@ class LutDataLoader(DataLoaderInterface):
         Raises:
             ValueError: aggregation type not in list of available methods
         '''
-        polygons = self.trim_datapoints(bounds)
+        polygons = self.trim_datapoints(bounds, data=data)
         logging.debug(f"\t{len(polygons)} polygons found for attribute " + \
                       f"'{self.data_name}' within bounds '{bounds}'")
         
@@ -337,7 +337,7 @@ class LutDataLoader(DataLoaderInterface):
         
         return { self.data_name: ret_val}
 
-    def get_hom_condition(self, bounds, splitting_conds):
+    def get_hom_condition(self, bounds, splitting_conds, data=None):
         '''
         Retrieves homogeneity condition of data within
         boundary.
@@ -361,7 +361,7 @@ class LutDataLoader(DataLoaderInterface):
         '''
         bounds_polygon = bounds.to_polygon()
         # Extract polygons that overlap the boundary
-        polygons = self.trim_datapoints(bounds)['geometry'].tolist()
+        polygons = self.trim_datapoints(bounds, data=data)['geometry'].tolist()
         
     
         # If there's no polygon that overlaps with bounds        

--- a/meshiphi/dataloaders/scalar/abstract_scalar.py
+++ b/meshiphi/dataloaders/scalar/abstract_scalar.py
@@ -426,7 +426,7 @@ class ScalarDataLoader(DataLoaderInterface):
         elif type(self.data) == xr.core.dataset.Dataset:
             return get_dp_from_coord_xr(self.data, data_name, long, lat, return_coords)
     
-    def get_value(self, bounds, agg_type=None, skipna=True):
+    def get_value(self, bounds, data=None, agg_type=None, skipna=True):
         '''
         Retrieve aggregated value from within bounds
         
@@ -550,7 +550,7 @@ class ScalarDataLoader(DataLoaderInterface):
             agg_type = self.aggregate_type
             
         # Limit data series to just the data, excluding coords/index
-        dps = self.trim_datapoints(bounds)[self.data_name]
+        dps = self.trim_datapoints(bounds, data=data)[self.data_name]
 
         if type(self.data) == pd.core.frame.DataFrame:
             value = get_value_from_df(dps, bounds, agg_type, skipna)
@@ -560,7 +560,7 @@ class ScalarDataLoader(DataLoaderInterface):
         # Cast to regular float before returning so can be saved in JSON later
         return {self.data_name: float(value)}
 
-    def get_hom_condition(self, bounds, splitting_conds):
+    def get_hom_condition(self, bounds, splitting_conds, data=None):
         '''
         Retrieves homogeneity condition of data within
         boundary.
@@ -674,7 +674,7 @@ class ScalarDataLoader(DataLoaderInterface):
         if 'split_lock' not in splitting_conds:
             splitting_conds['split_lock'] = False
 
-        dps = self.trim_datapoints(bounds)[self.data_name]
+        dps = self.trim_datapoints(bounds, data=data)[self.data_name]
         # Retrieve datapoints to analyse
         if type(dps) == pd.core.series.Series:
             return get_hom_condition_from_df(dps, splitting_conds)

--- a/meshiphi/dataloaders/scalar/abstract_scalar.py
+++ b/meshiphi/dataloaders/scalar/abstract_scalar.py
@@ -656,7 +656,6 @@ class ScalarDataLoader(DataLoaderInterface):
                 # Determine fraction of datapoints over threshold value
                 num_over_threshold = np.count_nonzero(dps > splitting_conds['threshold'])
                 frac_over_threshold = num_over_threshold/dps.size
-                       
                 # Return homogeneity condition
                 if   frac_over_threshold <= splitting_conds['lower_bound']: hom_type = "CLR"
                 elif frac_over_threshold >= splitting_conds['upper_bound']: 
@@ -673,8 +672,11 @@ class ScalarDataLoader(DataLoaderInterface):
         # Set default values for splitting_conds if not provided
         if 'split_lock' not in splitting_conds:
             splitting_conds['split_lock'] = False
+        if data is None:
+            dps = self.trim_datapoints(bounds)[self.data_name]
+        else:
+            dps = data[self.data_name]
 
-        dps = self.trim_datapoints(bounds, data=data)[self.data_name]
         # Retrieve datapoints to analyse
         if type(dps) == pd.core.series.Series:
             return get_hom_condition_from_df(dps, splitting_conds)

--- a/meshiphi/dataloaders/vector/abstract_vector.py
+++ b/meshiphi/dataloaders/vector/abstract_vector.py
@@ -429,7 +429,7 @@ class VectorDataLoader(DataLoaderInterface):
         elif type(self.data) == xr.core.dataset.Dataset:
             return get_dp_from_coord_xr(self.data, self.data_name_list, long, lat, return_coords)
     
-    def get_value(self, bounds, agg_type=None, skipna=True):
+    def get_value(self, bounds, agg_type=None, skipna=True, data=None):
         '''
         Retrieve aggregated value from within bounds
         
@@ -560,7 +560,10 @@ class VectorDataLoader(DataLoaderInterface):
             agg_type = self.aggregate_type
             
         # Limit data to boundary
-        dps = self.trim_datapoints(bounds)
+        if data is None:
+            dps = self.trim_datapoints(bounds, data=data)
+        else:
+            dps = data
         # Get list of values
         if type(self.data) == pd.core.frame.DataFrame:
             values = get_value_from_df(dps, self.data_name_list, bounds, agg_type, skipna)
@@ -570,7 +573,7 @@ class VectorDataLoader(DataLoaderInterface):
         # Put in dict to map variable to values
         return {self.data_name_list[i]: values[i] for i in range(len(self.data_name_list))}
 
-    def get_hom_condition(self, bounds, splitting_conds, agg_type='MEAN'):
+    def get_hom_condition(self, bounds, splitting_conds, agg_type='MEAN', data=None):
         '''
         Retrieves homogeneity condition of data within boundary. 
          
@@ -590,6 +593,9 @@ class VectorDataLoader(DataLoaderInterface):
                 'HET' = Threshold values defined in config are exceeded \n
                 'CLR' = None of the HET conditions were triggered \n
         '''
+        if data is None:
+            data = self.trim_datapoints(bounds)
+
         # Get length of dataset in bounds  
         if type(self.data) == pd.core.frame.DataFrame:
             num_dp = len(self.trim_datapoints(bounds))

--- a/meshiphi/mesh_generation/cellbox.py
+++ b/meshiphi/mesh_generation/cellbox.py
@@ -52,6 +52,7 @@ class CellBox:
         self.split_depth = 0
         self.data_source = None
         self.id = id
+        self.data_subset = None
 
 ######## setters and getters ########
     def set_minimum_datapoints(self, minimum_datapoints):
@@ -97,6 +98,12 @@ class CellBox:
         """
         self.id = id
 
+    def set_data_subset(self, data_subset):
+        """
+        sets the cellboxes data subset
+        """
+        self.data_subset = data_subset
+
     def get_id(self):
         """
         method returns cellbox cell id
@@ -137,6 +144,13 @@ class CellBox:
               has been split to reach it's current size.
         """
         return self.split_depth
+    
+
+    def get_data_subset(self):
+        """
+        gets the cellboxes data subset
+        """
+        return self.data_subset
 
 ######################################################
 # methods used for splitting a cellbox

--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -113,10 +113,18 @@ class MeshBuilder:
         # checking to avoid any dummy cellboxes (the ones that was splitted and replaced)
         logging.info("Assigning data sources to cellboxes...")
         for cellbox in cellboxes:
+            # Initialise data to be area within bounds of cellbox
+            
+            # for i, source in enumerate(meta_data_list):
+            #     # Add this to the metadata of the cellbox
+            #     source.set_data_subset(data_subsets[i])
+                
             if isinstance(cellbox, CellBox):
                 cellbox.set_minimum_datapoints(min_datapoints)
                 # assign meta data to each cellbox
-                cellbox.set_data_source(meta_data_list)
+                updated_meta_data_list = self.initialize_meta_data_subsets(cellbox.bounds, meta_data_list)
+                cellbox.set_data_source(updated_meta_data_list)
+
 
         
         logging.info("Initialising neighbour graph...")
@@ -158,11 +166,24 @@ class MeshBuilder:
                     data_source['params']['files'] = loader.files
 
                 meta_data_obj = Metadata(
-                    loader, updated_splitting_cond,  value_fill_type)
+                    loader, updated_splitting_cond,  value_fill_type, loader.data)
                 meta_data_list.append(meta_data_obj)
 
         return meta_data_list
         
+    def initialize_meta_data_subsets(self, bounds, meta_data_list):
+        logging.debug(f'Initilizing data subset for {bounds}')
+        updated_meta_data_list = []
+        for source in meta_data_list:
+            data_subset = source.data_loader.trim_datapoints(bounds)
+            updated_meta_data_list += [Metadata(source.get_data_loader(),
+                                                source.get_splitting_conditions(),
+                                                source.get_value_fill_type(),
+                                                data_subset)]
+        return updated_meta_data_list
+            
+
+
     def check_value_fill_type(self, data_source):
         def is_float(element: any) -> bool:
             if element is None: 

--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -103,26 +103,25 @@ class MeshBuilder:
         grid_width = (bounds.get_long_max() -
                       bounds.get_long_min()) / cell_width
 
-  
-
         min_datapoints = 5
         if 'splitting' in self.config:
             min_datapoints = self.config['splitting']['minimum_datapoints']
         meta_data_list = self.initialize_meta_data(bounds, min_datapoints)
 
-        # checking to avoid any dummy cellboxes (the ones that was splitted and replaced)
-        logging.info("Assigning data sources to cellboxes...")
-        for cellbox in cellboxes:
-            # Initialise data to be area within bounds of cellbox
-            
-            # for i, source in enumerate(meta_data_list):
-            #     # Add this to the metadata of the cellbox
-            #     source.set_data_subset(data_subsets[i])
-                
+        # Initialise the metadata for each cellbox, including subsets of each
+        # dataloader's data set
+        logging.info("Initialising cellbox metadata...")
+        for cellbox in tqdm(cellboxes, 
+                            bar_format='{desc}{n_fmt}/{total_fmt} |{bar}| {percentage:3.0f}%, [{elapsed} elapsed] '):
+            # checking to avoid any dummy cellboxes 
+            # (the ones that were split and replaced)
             if isinstance(cellbox, CellBox):
                 cellbox.set_minimum_datapoints(min_datapoints)
+                # Update metadata with cellbox's data subset
+                updated_meta_data_list = self.initialize_meta_data_subsets(
+                                                    cellbox.bounds, 
+                                                    meta_data_list)
                 # assign meta data to each cellbox
-                updated_meta_data_list = self.initialize_meta_data_subsets(cellbox.bounds, meta_data_list)
                 cellbox.set_data_source(updated_meta_data_list)
 
 
@@ -142,6 +141,21 @@ class MeshBuilder:
 
 
     def initialize_meta_data(self, bounds, min_datapoints):
+        '''
+        Creates a metadata object which holds information about the data sources
+        within a cellbox. 
+
+        Args:
+            bounds (Boundary):
+                Outer boundary of the mesh being created
+                
+            min_datapoints (int):
+                Minimum number of datapoints each dataloader is allowed to 
+                aggregate 
+        Returns:
+            list(Metadata):
+                Array of metadata objects; one for each data source
+        '''
         meta_data_list = []
         splitting_conds = []
         if 'data_sources' in self.config.keys():
@@ -172,14 +186,35 @@ class MeshBuilder:
         return meta_data_list
         
     def initialize_meta_data_subsets(self, bounds, meta_data_list):
+        '''
+        Updates cellbox metadata objects to include data subsets which contain
+        datapoints from only within the cellbox boundaries (as opposed to the
+        entire mesh's boundary)
+
+        Args:
+            bounds (Boundary):
+                Outer boundary of the cellbox
+                
+            meta_data_list (list(Metadata)):
+                Cellbox's metadata that needs to be updated with data subsets
+
+        Returns:
+            list(Metadata):
+                Array of metadata objects; one for each data source. Includes
+                data_subsets
+        '''
         logging.debug(f'Initilizing data subset for {bounds}')
         updated_meta_data_list = []
+        # For each set of data within the cellbox
         for source in meta_data_list:
+            # Limit data within dataloader to just that within cellbox boundary
             data_subset = source.data_loader.trim_datapoints(bounds)
+            # Update metadata object with this data subset
             updated_meta_data_list += [Metadata(source.get_data_loader(),
                                                 source.get_splitting_conditions(),
                                                 source.get_value_fill_type(),
                                                 data_subset)]
+            
         return updated_meta_data_list
             
 

--- a/meshiphi/mesh_generation/metadata.py
+++ b/meshiphi/mesh_generation/metadata.py
@@ -37,6 +37,12 @@ class Metadata:
         """
         return self.data_loader
 
+    def set_data_loader(self , data_loader): 
+        """
+        sets the data loader
+        """
+        self.data_loader = data_loader
+
     def get_splitting_conditions(self):
         """
         returns a list of the splitting conditions
@@ -44,29 +50,20 @@ class Metadata:
         
         return self.splitting_conditions
 
-    def set_data_loader(self , data_loader): 
-        """
-        sets the data loader
-        """
-        self.data_loader = data_loader
- 
-
     def set_splitting_conditions(self ,  splitting_conditions):
         """
         sets the splitting conditions
         """
         self.splitting_conditions = splitting_conditions
 
-    def set_value_fill_type(self , value_fill_type): 
-        """
-        sets the value fill type
-        """
-        self.value_fill_type = value_fill_type
-
     def get_value_fill_type(self ):
         """
         returns thevalue fill type
         """
         return self.value_fill_type   
-  
 
+    def set_value_fill_type(self , value_fill_type): 
+        """
+        sets the value fill type
+        """
+        self.value_fill_type = value_fill_type

--- a/meshiphi/mesh_generation/metadata.py
+++ b/meshiphi/mesh_generation/metadata.py
@@ -17,7 +17,7 @@ class Metadata:
     """
    
 
-    def __init__(self, data_loader , spliiting_conditions =None, value_fill_type= ""):
+    def __init__(self, data_loader , splitting_conditions =None, value_fill_type= "", data_subset=None):
         """
 
             Args:
@@ -28,8 +28,16 @@ class Metadata:
                 
         """ 
         self.data_loader = data_loader
-        self.splitting_conditions = spliiting_conditions
+        self.splitting_conditions = splitting_conditions
         self.value_fill_type = value_fill_type
+        self.data_name = data_loader.data_name
+        if data_subset is None:
+            if ',' in data_loader.data_name:
+                self.data_subset = data_loader.data[data_loader.data_name.split(',')]
+            else:
+                self.data_subset = data_loader.data[data_loader.data_name]
+        else:
+            self.data_subset = data_subset
   
     def get_data_loader(self): 
         """
@@ -67,3 +75,15 @@ class Metadata:
         sets the value fill type
         """
         self.value_fill_type = value_fill_type
+
+    def get_data_subset(self):
+        """
+        gets the data subset
+        """
+        return self.data_subset
+    
+    def set_data_subset(self, data_subset):
+        """
+        sets the data subset
+        """
+        self.data_subset = data_subset


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-03-07
Version Number: 2.0.3
 
## Description of change
Cellboxes now store pointers to subsets of the data within each dataloader. Before this change, dataloaders were decoupled from cellboxes, however this meant that each time data was requested, the dataloader would have to locate the relevant datapoints across the entire dataset. For xarray data, this was no problem, however for large pandas dataframes (particularly after reprojection), selecting data within the datasets became very cumbersome due to slow indexing. 

Now a subset of each data source is stored in each cellbox, dramatically reducing the number of rows to iterate though. There is an initial set up cost in that the initial unsplit mesh has to be populated with data before any splitting occurs, but after that the process is much faster. TQDM logging has been added during this process for greater transparency of processes to the user. 


## Fixes #42 

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  
> Changes to the following files:
> _meshiphi/dataloaders/lut/abstract_lut.py_
> _meshiphi/dataloaders/lut/thickness.py_
> _meshiphi/dataloaders/scalar/abstract_scalar.py_
> _meshiphi/dataloaders/vector/abstract_vector.py_
> _meshiphi/mesh_generation/cellbox.py_
> _meshiphi/mesh_generation/mesh_builder.py_
> _meshiphi/mesh_generation/metadata.py_

[Passing reg tests](https://github.com/antarctica/MeshiPhi/files/14526651/pytest_output.txt)

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.0.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
