### PR TITLE
Baltic dataloader fixes

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.3"
+__version__ = "2.0.4"
 
 __description__ = "meshiphi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"

--- a/meshiphi/dataloaders/lut/thickness.py
+++ b/meshiphi/dataloaders/lut/thickness.py
@@ -20,6 +20,7 @@ southern_seasons = {
     9: 'sp', 10: 'sp', 11: 'sp',
     }
 
+
 class ThicknessDataLoader(LutDataLoader):
     
     class Region:
@@ -45,8 +46,7 @@ class ThicknessDataLoader(LutDataLoader):
                 float: Sea Ice Density in the specified season
             """
             return self.value_dict[self.month_to_season[month]]
-        
-    
+
     def import_data(self, bounds):
         """
         Creates a simulated dataset of sea ice thickness based on 
@@ -83,8 +83,15 @@ class ThicknessDataLoader(LutDataLoader):
             self.Region('Ross W', 
                         Boundary([-90, 0], [160,   180]).to_polygon(),
                         {'wi': 0.72, 'sp': 0.67, 'su': 1.32, 'au': 0.82, 'y': 1.07}),
+            # Baltic thickness to match example from arxiv paper
+            self.Region('Baltic',
+                        Boundary([54, 66], [12, 32]).to_polygon(),
+                        {'wi': 0.3, 'sp': 0.3, 'su': 0.3, 'au': 0.3, 'y': 0.3},
+                        seasons=northern_seasons),
+            # Keep previous defaults everywhere else
             self.Region('None',
-                        Boundary([0, 90], [-180, 180]).to_polygon(),
+                        Polygon([(-180, 0), (180, 0), (180, 90), (-180, 90)],
+                                holes=[[(12, 54), (32, 54), (32, 66), (12, 66)]]),
                         {'wi': 0.72, 'sp': 0.67, 'su': 1.32, 'au': 0.82, 'y': 1.07},
                         seasons=northern_seasons),
         ]
@@ -102,13 +109,13 @@ class ThicknessDataLoader(LutDataLoader):
             
             intersection = region.geometry & bounds_polygon
             if intersection.geom_type in ['Polygon', 'MultiPolygon'] and \
-                intersection != Polygon():
+               intersection != Polygon():
                     
                 region_df = pd.concat([
                         pd.DataFrame({'time': dates,
-                                    'geometry': region.geometry & bounds_polygon,
-                                    'thickness': region.get_value(month)})
-                            for month  in dates.month
+                                      'geometry': region.geometry & bounds_polygon,
+                                      'thickness': region.get_value(month)})
+                        for month in dates.month
                     ])
                 
                 thickness_df = pd.concat([thickness_df, region_df])

--- a/meshiphi/dataloaders/scalar/abstract_scalar.py
+++ b/meshiphi/dataloaders/scalar/abstract_scalar.py
@@ -320,14 +320,6 @@ class ScalarDataLoader(DataLoaderInterface):
         if data is None:
             data = self.data
         
-        # Skip trimming if data already completely within bounds
-        if data.lat.min() >  bounds.get_lat_min() and \
-           data.lat.max() <= bounds.get_lat_max() and \
-           data.long.min() >  bounds.get_long_min() and \
-           data.long.max() <= bounds.get_long_max():
-            logging.debug('\tData is already trimmed to bounds!')
-            return data
-        
         if type(data) == pd.core.frame.DataFrame:
             return trim_datapoints_from_df(data, bounds)
         elif type(data) == xr.core.dataset.Dataset:

--- a/meshiphi/dataloaders/vector/abstract_vector.py
+++ b/meshiphi/dataloaders/vector/abstract_vector.py
@@ -362,14 +362,6 @@ class VectorDataLoader(DataLoaderInterface):
         # If no specific data passed in, default to entire dataset
         if data is None:
             data = self.data
-            
-        # Skip trimming if data already completely within bounds
-        if data.lat.min() >  bounds.get_lat_min() and \
-           data.lat.max() <= bounds.get_lat_max() and \
-           data.long.min() >  bounds.get_long_min() and \
-           data.long.max() <= bounds.get_long_max():
-            logging.debug('\tData is already trimmed to bounds!')
-            return data
         
         if type(data) == pd.core.frame.DataFrame:
             return trim_datapoints_from_df(data, bounds)

--- a/meshiphi/dataloaders/vector/baltic_current.py
+++ b/meshiphi/dataloaders/vector/baltic_current.py
@@ -4,31 +4,39 @@ import logging
  
 import xarray as xr
 
+
 class BalticCurrentDataLoader(VectorDataLoader):
     def import_data(self, bounds):
-        '''
+        """
         Reads in current data from a copernicus baltic sea physics reanalysis NetCDF file.
-        Renames coordinates to 'lat' and 'long', and renames variable to 
+        Renames coordinates to 'lat' and 'long', and renames variable to
         'uC, vC'
-        
+
         Args:
             bounds (Boundary): Initial boundary to limit the dataset to
-            
+
         Returns:
-            xr.Dataset: 
-                Baltic currents dataset within limits of bounds. 
+            xr.Dataset:
+                Baltic currents dataset within limits of bounds.
                 Dataset has coordinates 'lat', 'long', and variable 'uC', 'vC'
-        '''
+        """
         # Open Dataset
         if len(self.files) == 1:    data = xr.open_dataset(self.files[0])
         else:                       data = xr.open_mfdataset(self.files)
+
+        # Reduce and drop unused depth dimension
+        data = data.isel(depth=0)
+        data = data.reset_coords(names="depth", drop=True)
         # Change column names
         data = data.rename({'latitude': 'lat',
                             'longitude': 'long',
                             'uo': 'uC',
                             'vo': 'vC'})
-        
+
         # Trim to initial datapoints
         data = self.trim_datapoints(bounds, data=data)
+
+        # Reduce along time dimension
+        data = data.mean(dim="time")
         
         return data


### PR DESCRIPTION
# MeshiPhi Pull Request

Date: 14/03/24  
Version Number: 2.0.4
 
## Description of change
Fix to get the Baltic current dataloader working again and add a thickness region for the Baltic Sea that matches the values used in a previous example. Also removes a set of if statements that could cause an error when splitting to a cell size close to the data resolution.

## Fixes # (issue)
N/A

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  

Test dump:
[mesh_test_dump.txt](https://github.com/antarctica/MeshiPhi/files/14603294/mesh_test_dump.txt)

  
Files changed:

```
meshiphi/__init__.py
meshiphi/dataloaders/lut/thickness.py
meshiphi/dataloaders/scalar/abstract_scalar.py
meshiphi/dataloaders/vector/abstract_vector.py
meshiphi/dataloaders/vector/baltic_current.py
```

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
