### PR TITLE
Cell ids for resplit mesh

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.4"
+__version__ = "2.0.5"
 
 __description__ = "meshiphi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"

--- a/meshiphi/mesh_generation/environment_mesh.py
+++ b/meshiphi/mesh_generation/environment_mesh.py
@@ -164,10 +164,10 @@ class EnvironmentMesh:
         bounds = cellbox.get_bounds()
         split_bounds = bounds.split()
 
-        cellbox1 = AggregatedCellBox(split_bounds[0], agg_data1, max_id + 1)
-        cellbox2 = AggregatedCellBox(split_bounds[1], agg_data2, max_id + 2)
-        cellbox3 = AggregatedCellBox(split_bounds[2], agg_data3, max_id + 3)
-        cellbox4 = AggregatedCellBox(split_bounds[3], agg_data4, max_id + 4)
+        cellbox1 = AggregatedCellBox(split_bounds[0], agg_data1, str(max_id + 1))
+        cellbox2 = AggregatedCellBox(split_bounds[1], agg_data2, str(max_id + 2))
+        cellbox3 = AggregatedCellBox(split_bounds[2], agg_data3, str(max_id + 3))
+        cellbox4 = AggregatedCellBox(split_bounds[3], agg_data4, str(max_id + 4))
 
         # Update neighbour graph
 


### PR DESCRIPTION
# MeshiPhi Pull Request

Date: 22/03/24 
Version Number: 2.0.5
 
## Description of change
Cast cell ids to `str` when resplitting an environmental mesh.

## Fixes # (issue)
N/A

# Testing

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
Files changed:
```
meshiphi/mesh_generation/environment_mesh.py
```
Test dump:
[test_dump.txt](https://github.com/antarctica/MeshiPhi/files/14724187/test_dump.txt)


# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
