### PR TITLE
Duacs dataloader fix

### DIFF
--- a/meshiphi/dataloaders/vector/duacs_current.py
+++ b/meshiphi/dataloaders/vector/duacs_current.py
@@ -38,8 +38,10 @@ class DuacsCurrentDataLoader(VectorDataLoader):
                             'longitude': 'long',
                             'ugos': 'uC',
                             'vgos': 'vC'})
-        # Drop unnecessary variable
-        data = data.drop_vars('crs')
+
+        # Drop unnecessary variable, if present
+        if 'crs' in data.keys():
+            data = data.drop_vars('crs')
 
         # Trim to initial datapoints
         data = self.trim_datapoints(bounds, data=data)


### PR DESCRIPTION
# MeshiPhi Pull Request

Date: 24/04/24   
Version Number: 2
 
## Description of change
Add a check to the duacs dataloader such that it will only try to drop the `crs` variable when it is actually present in the dataset.

## Fixes #55 

# Testing

- [x] My changes have not altered any of the files listed in the testing strategy

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
Files changed:
```
meshiphi/dataloaders/vector/duacs_current.py
```

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.0.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
