### PR TITLE
Dataloader minor fixes

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.7"
+__version__ = "2.0.8"
 
 __description__ = "meshiphi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"

--- a/meshiphi/dataloaders/lut/density.py
+++ b/meshiphi/dataloaders/lut/density.py
@@ -67,8 +67,10 @@ class DensityDataLoader(LutDataLoader):
         # Remove empty geometry rows from df
         drop_idxs = []
         for idx, row in density_df.iterrows():
-            if row['geometry'].is_empty:
+            if row['geometry'].is_empty or \
+               row['geometry'].geom_type not in ['Polygon', 'MultiPolygon']:
                 drop_idxs += [idx]
+
         density_df.drop(index=drop_idxs, inplace=True)
         density_df.drop(columns=['index'], inplace=True)
 

--- a/meshiphi/dataloaders/scalar/abstract_scalar.py
+++ b/meshiphi/dataloaders/scalar/abstract_scalar.py
@@ -81,9 +81,9 @@ class ScalarDataLoader(DataLoaderInterface):
                      "of initial boundary")
         # If there's 0 datapoints in the initial boundary, raise ValueError
         if data_coverage == 0:
-            logging.error('\tDataloader has no data in initial region!')
-            raise ValueError(f"Dataloader {params['dataloader_name']}"+\
-                              " contains no data within initial region!")
+            logging.warning('\tDataloader has no data in initial region!')
+            #raise ValueError(f"Dataloader {params['dataloader_name']}"+\
+            #                  " contains no data within initial region!")
         else:
             # Cut dataset down to initial boundary
             logging.info(

--- a/meshiphi/dataloaders/vector/abstract_vector.py
+++ b/meshiphi/dataloaders/vector/abstract_vector.py
@@ -83,9 +83,9 @@ class VectorDataLoader(DataLoaderInterface):
                      "of initial boundary")
         # If there's 0 datapoints in the initial boundary, raise ValueError
         if data_coverage == 0:
-            logging.error('\tDataloader has no data in initial region!')
-            raise ValueError(f"Dataloader {params['dataloader_name']}"+\
-                              " contains no data within initial region!")
+            logging.warning('\tDataloader has no data in initial region!')
+            # raise ValueError(f"Dataloader {params['dataloader_name']}"+\
+                            #   " contains no data within initial region!")
         else:
             # Cut dataset down to initial boundary
             logging.info(


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-04-24
Version Number: 2.0.8
 
## Description of change
Fixing dataloader issues encountered when testing mosaicing a global mesh. Density dataloader was spitting out linestrings along the equator, which hold no data (because they have no area), so these were removed. 
Meshes were erroring when dataloaders were included that had no data in the config region (e.g. AMSR northern for a southern config). This errored out when realistically it's more useful for that to be a warning, so I demoted it.
Finally, the coverage percentage calculated was actually incorrect; it was calculating the percentage difference in area between data and mesh config, but it wasn't taking into account the actual overlap region. This has been fixed.

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy

> Only touches dataloaders, and tests aren't set up yet. I still ran them anyway and everything passed.

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.0..x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   