### PR TITLE
Fixing incorrect calculation of grid_width for cellboxes larger than …

### DIFF
--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -101,9 +101,10 @@ class MeshBuilder:
      
         cellboxes = []
         cellboxes = self.initialize_cellboxes(bounds, cell_width, cell_height)
-        # Account for going over the antimeridian with longitude_distance
-        grid_width = longitude_distance(bounds.get_long_min(), 
-                                        bounds.get_long_max()) / cell_width
+        
+        # Account for going over the antimeridian with longitude_distance        
+        grid_width = np.divide(bounds.get_long_max() - bounds.get_long_min(),
+                               cell_width)
         
         min_datapoints = 5
         if 'splitting' in self.config:


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-04-25
Version Number: 2.0.8
 
## Description of change
Fixing bug found when generating global meshes, the longitude distance calculation was returning 0 degrees instead of 360 degrees. This is essentially just reverting a change made within the recent antimeridian feature.

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
[Passing reg tests](https://github.com/antarctica/MeshiPhi/files/15111444/pytest_meshiphi.txt)

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.0.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
