### PR TITLE
Mesh validation

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,5 @@
-__version__ = "2.1.2"
+__version__ = "2.1.3"
+
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/meshiphi/mesh_validation/full_mesh_validator.py
+++ b/meshiphi/mesh_validation/full_mesh_validator.py
@@ -1,0 +1,133 @@
+
+from meshiphi.mesh_generation.environment_mesh import EnvironmentMesh
+import pandas as pd
+import json
+import math
+
+class FullMeshValidator:
+    """
+    A class that validates a constructed mesh against its actual sourced geo-spatial data. 
+    Validation takes place by comparing the aggregated data value of mesh's cellbox against the 
+    actual data contained within cellbox's bounds.
+
+    This object compares all source data contained within the mesh to the mesh data, where as the
+    MeshValidator object only compares a sample of the source data to the mesh data.
+    """
+
+    def __init__(self, mesh, source_data):
+        """
+        Args: 
+            mesh: json file containing mesh data
+            source_data: DataFrame containing source data. Must contain columns 'lat' and 'long'
+        """
+        self.mesh = EnvironmentMesh.load_from_json(mesh)
+        self.source_data = source_data
+
+        # Validate that the source data contains the required columns
+        if 'lat' not in self.source_data.columns:
+            raise ValueError("Source data must contain column 'lat'")
+        if 'long' not in self.source_data.columns:
+            raise ValueError("Source data must contain column 'long'")
+
+        # Validate that the source data is within the require bounds
+
+    def validate_vector(self, sd_name, md_name):
+        """
+        Validate the mesh by comparing the vector field in the mesh to the source data
+        Args:
+            sd_name: name of source data vector field
+            md_name: name of mesh vector field
+
+        Returns:
+            validation_results: dictionary containing validation results
+        """
+
+        full_raw_processed = pd.DataFrame()
+        for cell_count in range(len(self.mesh.agg_cellboxes)):
+
+            # Get slice of data within cellbox
+            bounds = self.mesh.agg_cellboxes[cell_count].get_bounds()
+            raw_slice = self.slice_data(bounds)
+
+            # Get vector value from cellbox
+            cell_vector_0 = 'cell_' + md_name[0]
+            cell_vector_1 = 'cell_' + md_name[1]
+            raw_slice[cell_vector_0] = self.mesh.agg_cellboxes[cell_count].get_agg_data()[md_name[0]]
+            raw_slice[cell_vector_1] = self.mesh.agg_cellboxes[cell_count].get_agg_data()[md_name[1]]
+
+            # Calculate difference vector
+
+            raw_slice['d_vector_0'] = raw_slice[sd_name[0]] - raw_slice[cell_vector_0]
+            raw_slice['d_vector_1'] = raw_slice[sd_name[1]] - raw_slice[cell_vector_1]
+
+            # Calculate magnitude of difference vector (used as error metric)
+            raw_slice['d_vector_mag'] = (raw_slice['d_vector_0']**2 + raw_slice['d_vector_1']**2) ** 0.5
+            raw_slice['d_vector_mag^2'] = raw_slice['d_vector_mag']**2 
+
+            full_raw_processed = pd.concat([full_raw_processed, raw_slice])
+
+        # Calculate mean magnitude of difference vector
+        mean_d_vector_mag = full_raw_processed['d_vector_mag'].mean()
+        rms_d_vector_mag = (full_raw_processed['d_vector_mag^2'].mean()) ** 0.5
+
+        validation_results = {
+            'cellbox_count': len(self.mesh.agg_cellboxes),
+            'mean_d_vector_mag': mean_d_vector_mag,
+            'root_mean_squared_d_vector_mag': rms_d_vector_mag
+        }
+
+        return validation_results
+
+    def validate_scalar(self, sd_name, md_name):
+        """
+        Validate the mesh by comparing the scalar field in the mesh to the source data
+        Args:
+            sd_name: name of source data scalar field
+            md_name: name of mesh scalar field
+
+        Returns:
+            validation_results: dictionary containing validation results
+        """
+        full_raw_processed = pd.DataFrame()
+
+        for cell_count in range(len(self.mesh.agg_cellboxes)):
+            # Get slice of data within cellbox
+            bounds = self.mesh.agg_cellboxes[cell_count].get_bounds()
+            raw_slice = self.slice_data(bounds)
+
+            # Get scalar value from cellbox
+            cell_scalar = 'cell_' + md_name
+            raw_slice[cell_scalar] = self.mesh.agg_cellboxes[cell_count].get_agg_data()[md_name]
+
+            # Calculate difference scalar
+            raw_slice['d_scalar'] = abs(raw_slice[sd_name] - raw_slice[cell_scalar])
+            raw_slice['d_scalar^2'] = raw_slice['d_scalar']**2
+
+            full_raw_processed = pd.concat([full_raw_processed, raw_slice])
+
+        mean_err = full_raw_processed['d_scalar'].mean()
+        rmse = (full_raw_processed['d_scalar^2'].mean()) ** 0.5
+
+        validation_results = {
+            'cellbox_count': len(self.mesh.agg_cellboxes),
+            'mean_err': mean_err,
+            'root_mean_squared_err': rmse
+        }
+
+        return validation_results
+
+
+    def slice_data(self, bounds):
+        """
+        return a slice of the source data within the bounds
+        Args:
+        bounds: Bounds object containing bounds to slice data with
+
+        Returns:
+        raw_slice: DataFrame containing slice of data
+        """
+
+        raw_slice = self.source_data[self.source_data['lat'].between(bounds.lat_range[0], bounds.lat_range[1])]
+        raw_slice = raw_slice[raw_slice['long'].between(bounds.long_range[0], bounds.long_range[1])]
+    
+        return raw_slice


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 30/04/2024
Version Number: 2.1.2 --> 2.1.3
 
## Description of change
Inclusion of a mesh validator object, which compares a mesh to the source data used to create it and returns a results dictionary including the mean error and root-mean-squared-error of the mesh relative to it's source data.

## Fixes # (issue)
https://github.com/antarctica/MeshiPhi/issues/21

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy
[test_dump.txt](https://github.com/antarctica/MeshiPhi/files/15165609/test_dump.txt)

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
> *list which files have been altered and include a pytest.txt file for each of
> the tests required to be run*
>
> The files which have been changed during this PR can be listed using the command

meshiphi/__init__.py
meshiphi/mesh_validation/full_mesh_validator.py


- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

> *include pytest.txt file showing which tests fail.*  
> *include reasoning as to why your changes cause these tests to fail.* 
>
> Should these changes be valid, relevant test files should be updated.  
> *include pytest.txt file of test passing after test files have been updated.*

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `1.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
