### PR TITLE
Global mesh hotfix

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.0.8"
+__version__ = "2.0.9"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/meshiphi/config_validation/config_validator.py
+++ b/meshiphi/config_validation/config_validator.py
@@ -94,7 +94,7 @@ def validate_mesh_config(config):
             bound_max (float): Maximum value of boundary in the same axis
             cell_size (float): Initial cellbox size in the same axis
         """
-        assert(((bound_max - bound_min)/cell_size)%1 == 0), \
+        assert(((bound_max - bound_min)%360/cell_size)%1 == 0), \
             f"{bound_max}-{bound_min}={bound_max-bound_min} is not evenly "+\
             f"divided by {cell_size}"
         

--- a/meshiphi/mesh_generation/boundary.py
+++ b/meshiphi/mesh_generation/boundary.py
@@ -278,7 +278,7 @@ class Boundary:
         """
             returns the max longtitude
         """
-        return self.long_range[1]  
+        return self.long_range[1]
     def get_time_min(self):
         """
             returns the min of time range
@@ -334,7 +334,7 @@ class Boundary:
                 Shapely polygon with corners at the min/max lat/long 
                 values of this boundary
         """
-        # If not going over the antimeridian
+        # If boundary not going over the antimeridian
         if self.get_long_min() < self.get_long_max():
             # Create a polygon of boundary
             polygon = wkt.loads(
@@ -344,6 +344,22 @@ class Boundary:
                                 f'{self.get_long_max()} {self.get_lat_min()},' + \
                                 f'{self.get_long_min()} {self.get_lat_min()}))'
                 )
+        elif self.get_long_min() == 180:
+            polygon = wkt.loads(
+                        f'POLYGON((-180 {self.get_lat_min()},' + \
+                                f'-180 {self.get_lat_max()},' + \
+                                f'{self.get_long_max()} {self.get_lat_max()},' + \
+                                f'{self.get_long_max()} {self.get_lat_min()},' + \
+                                f'-180 {self.get_lat_min()}))'
+                )
+        elif self.get_long_max() == -180:
+            polygon = wkt.loads(
+                        f'POLYGON(({self.get_long_min()} {self.get_lat_min()},' + \
+                                f'{self.get_long_min()} {self.get_lat_max()},' + \
+                                f'180 {self.get_lat_max()},' + \
+                                f'180 {self.get_lat_min()},' + \
+                                f'{self.get_long_min()} {self.get_lat_min()}))'
+            )
         else:
             # Create a multipolygon of boundary
             polygon_1 = wkt.loads(

--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -102,9 +102,15 @@ class MeshBuilder:
         cellboxes = []
         cellboxes = self.initialize_cellboxes(bounds, cell_width, cell_height)
         
-        # Account for going over the antimeridian with longitude_distance        
-        grid_width = np.divide(bounds.get_long_max() - bounds.get_long_min(),
-                               cell_width)
+        # If global mesh
+        if bounds.get_width() == 360:
+            # Account for going over the antimeridian manually       
+            grid_width = np.divide(bounds.get_long_max() - bounds.get_long_min(),
+                                cell_width)
+        else:
+            # Account for going over the antimeridian with longitude_distance        
+            grid_width = longitude_distance(bounds.get_long_min(), 
+                                            bounds.get_long_max()) / cell_width
         
         min_datapoints = 5
         if 'splitting' in self.config:

--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -103,8 +103,7 @@ class MeshBuilder:
         cellboxes = self.initialize_cellboxes(bounds, cell_width, cell_height)
         
         # Calculate width of mesh in cell-coordinates rather than degrees
-        grid_width = np.divide(bounds.get_width(),
-                            cell_width)
+        grid_width = np.divide(bounds.get_width(), cell_width)
         
         min_datapoints = 5
         if 'splitting' in self.config:

--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -343,7 +343,7 @@ class MeshBuilder:
         
 
     def validate_bounds(self, bounds, cell_width, cell_height):
-        assert (bounds.get_long_max() - bounds.get_long_min()) % cell_width == 0, \
+        assert (bounds.get_long_max() - bounds.get_long_min()) % 360 % cell_width == 0, \
             f"""The defined longitude region <{bounds.get_long_min()} :{bounds.get_long_max()}>
             is not divisable by the initial cell width <{cell_width}>"""
 

--- a/meshiphi/mesh_generation/mesh_builder.py
+++ b/meshiphi/mesh_generation/mesh_builder.py
@@ -102,15 +102,9 @@ class MeshBuilder:
         cellboxes = []
         cellboxes = self.initialize_cellboxes(bounds, cell_width, cell_height)
         
-        # If global mesh
-        if bounds.get_width() == 360:
-            # Account for going over the antimeridian manually       
-            grid_width = np.divide(bounds.get_long_max() - bounds.get_long_min(),
-                                cell_width)
-        else:
-            # Account for going over the antimeridian with longitude_distance        
-            grid_width = longitude_distance(bounds.get_long_min(), 
-                                            bounds.get_long_max()) / cell_width
+        # Calculate width of mesh in cell-coordinates rather than degrees
+        grid_width = np.divide(bounds.get_width(),
+                            cell_width)
         
         min_datapoints = 5
         if 'splitting' in self.config:


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-05-15
Version Number: 2.0.9
 
## Description of change
Grid width calculation was producing weird neighbour graph results where it was being populated with non-existant cellboxes with negative ID's. This was traced back to a previous fix where global meshes couldn't be calculated due to there being 0 degrees difference between -180 and 180. Instead of calculating the grid_width from the long_min/max values, it is now calculated from the boundary get_width() method, which already compensates for the antimeridian case. 

In addition to this, cellboxes with a boundary on the antimeridian were generating WKT's as multipolygons, with zero-width polygons on the antimeridian. This is now fixed and the WKTs should just be Polygons now.

Also amended some verification steps that were failing due to the initial mesh boundary spanning the antimeridian

## Fixes #67 

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  
  
[Passing reg tests](https://github.com/antarctica/MeshiPhi/files/15322298/pytest_output.log)

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [] My PR has been made to the `2.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
