### PR TITLE
Test automator hotfix

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.6"
+__version__ = "2.1.8"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/meshiphi/test_automation/test_automater.py
+++ b/meshiphi/test_automation/test_automater.py
@@ -432,9 +432,10 @@ class TestAutomater:
             identical_meshes = [df.empty for df in comparison.values()]
             # If no difference in meshes, remove the file
             if all(identical_meshes):
-                shutil.rmtree(pytest_output_basename+'.json')
+                os.remove(pytest_output_basename+'.json')
                 # Remove plot if it exists
-                shutil.rmtree(pytest_output_basename+'.svg',  ignore_errors=True)
+                if os.path.isfile(pytest_output_basename+'.svg'):
+                    os.remove(pytest_output_basename+'.svg')
             # If there is a difference, move the file to current directory
             else:
                 save_filename = os.path.join(output_folder, 


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-05-23
Version Number: 2.1.8
 
## Description of change
Fixes bug found while creating new unit tests. Temporary files were not being deleted properly, and instead threw a FileError. Was using shutil.rmtree(), but instead have changed to os.remove() with an additional check to see if the file exists before removing.

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  