### PR TITLE
Test CLI

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -36,5 +36,6 @@ UNIT_TESTS_BY_FILE = {
     'boundary.py':          ['test_boundary.py'],
     'cellbox.py':           ['test_cellbox.py'],
     'direction.py':         [],
-    'environment_mesh.py':  ['test_env_mesh.py']
+    'environment_mesh.py':  ['test_env_mesh.py'],
+    'cli.py':               ['test_cli.py']
 }

--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.9"
+__version__ = "2.1.10"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -49,11 +49,11 @@ class TestCLI (unittest.TestCase):
 
     def tearDown(self):
         self.tmp_config_file.close()
-        self.tmp_mesh_file.close()  
-        self.tmp_mesh_file_1.close()    
-        self.tmp_mesh_file_2.close()    
-        self.tmp_merge_file.close() 
-        self.tmp_output_file.close()    
+        self.tmp_mesh_file.close()
+        self.tmp_mesh_file_1.close()
+        self.tmp_mesh_file_2.close()
+        self.tmp_merge_file.close()
+        self.tmp_output_file.close()
     
     def test_get_args_cli(self):
         raise NotImplementedError

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,0 +1,109 @@
+from meshiphi.cli import get_args
+from meshiphi.cli import rebuild_mesh_cli
+from meshiphi.cli import create_mesh_cli
+from meshiphi.cli import export_mesh_cli
+from meshiphi.cli import merge_mesh_cli
+from meshiphi.cli import meshiphi_test_cli
+
+
+import tempfile
+import sys
+import unittest
+import filecmp
+import difflib
+import json
+from unittest.mock import patch
+
+
+# Contents of JSON files to run through each CLI command with
+# Config to create BASIC_OUTPUT
+BASIC_CONFIG = {"region":{"lat_min":-10,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}
+# Mesh to rebuild to create BASIC_OUTPUT
+BASIC_MESH   = {"config":{"mesh_info":{"region":{"lat_min":-10,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}},"cellboxes":[{"geometry":"POLYGON ((-10 -10, -10 0, 0 0, 0 -10, -10 -10))","cx":-5,"cy":-5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 -10, 0 0, 10 0, 10 -10, 0 -10))","cx":5,"cy":-5,"dcx":5,"dcy":5,"id":"1"},{"geometry":"POLYGON ((-10 0, -10 10, 0 10, 0 0, -10 0))","cx":-5,"cy":5,"dcx":5,"dcy":5,"id":"2"},{"geometry":"POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))","cx":5,"cy":5,"dcx":5,"dcy":5,"id":"3"}],"neighbour_graph":{"0":{"1":[3],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[2]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[2],"-4":[3]},"2":{"1":[],"2":[3],"3":[1],"4":[0],"-1":[],"-2":[],"-3":[],"-4":[]},"3":{"1":[],"2":[],"3":[],"4":[1],"-1":[0],"-2":[2],"-3":[],"-4":[]}}}
+BASIC_OUTPUT = {"config":{"mesh_info":{"region":{"lat_min":-10,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}},"cellboxes":[{"geometry":"POLYGON ((-10 -10, -10 0, 0 0, 0 -10, -10 -10))","cx":-5,"cy":-5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 -10, 0 0, 10 0, 10 -10, 0 -10))","cx":5,"cy":-5,"dcx":5,"dcy":5,"id":"1"},{"geometry":"POLYGON ((-10 0, -10 10, 0 10, 0 0, -10 0))","cx":-5,"cy":5,"dcx":5,"dcy":5,"id":"2"},{"geometry":"POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))","cx":5,"cy":5,"dcx":5,"dcy":5,"id":"3"}],"neighbour_graph":{"0":{"1":[3],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[2]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[2],"-4":[3]},"2":{"1":[],"2":[3],"3":[1],"4":[0],"-1":[],"-2":[],"-3":[],"-4":[]},"3":{"1":[],"2":[],"3":[],"4":[1],"-1":[0],"-2":[2],"-3":[],"-4":[]}}}
+# Meshes to merge to produce BASIC_MERGED_MESH
+BASIC_HALF_MESH_1 = {"config":{"mesh_info":{"region":{"lat_min":-10,"lat_max":0,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}},"cellboxes":[{"geometry":"POLYGON ((-10 -10, -10 0, 0 0, 0 -10, -10 -10))","cx":-5,"cy":-5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 -10, 0 0, 10 0, 10 -10, 0 -10))","cx":5,"cy":-5,"dcx":5,"dcy":5,"id":"1"}],"neighbour_graph":{"0":{"1":[],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[],"-4":[]}}}
+BASIC_HALF_MESH_2 = {"config":{"mesh_info":{"region":{"lat_min":0,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}},"cellboxes":[{"geometry":"POLYGON ((-10 0, -10 10, 0 10, 0 0, -10 0))","cx":-5,"cy":5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))","cx":5,"cy":5,"dcx":5,"dcy":5,"id":"1"}],"neighbour_graph":{"0":{"1":[],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[],"-4":[]}}}
+BASIC_MERGED_MESH = {"config":{"mesh_info":{"region":{"lat_min":-10,"lat_max":0,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5},"merged":[{"region":{"lat_min":0,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}]}},"cellboxes":[{"geometry":"POLYGON ((-10 -10, -10 0, 0 0, 0 -10, -10 -10))","cx":-5,"cy":-5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 -10, 0 0, 10 0, 10 -10, 0 -10))","cx":5,"cy":-5,"dcx":5,"dcy":5,"id":"1"},{"geometry":"POLYGON ((-10 0, -10 10, 0 10, 0 0, -10 0))","cx":-5,"cy":5,"dcx":5,"dcy":5,"id":"2"},{"geometry":"POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))","cx":5,"cy":5,"dcx":5,"dcy":5,"id":"3"}],"neighbour_graph":{"0":{"1":[3],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[2]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[2],"-4":[3]},"2":{"1":[],"2":[3],"3":[1],"4":[0],"-1":[],"-2":[],"-3":[],"-4":[]},"3":{"1":[],"2":[],"3":[],"4":[1],"-1":[0],"-2":[2],"-3":[],"-4":[]}}}
+
+def json_dict_to_file(json_dict, filename):
+    with open(filename, 'w') as fp:
+        json.dump(json_dict, fp, indent=4)
+
+def file_to_json(filename):
+    with open(filename, 'r') as fp:
+        json_dict = json.load(fp)
+    return json_dict
+
+class TestCLI (unittest.TestCase):
+
+    def setUp(self):
+        self.output_base_directory = tempfile.mkdtemp()
+        self.tmp_config_file = tempfile.NamedTemporaryFile()
+        self.tmp_mesh_file   = tempfile.NamedTemporaryFile()
+        self.tmp_mesh_file_1 = tempfile.NamedTemporaryFile()
+        self.tmp_mesh_file_2 = tempfile.NamedTemporaryFile()
+        self.tmp_merge_file  = tempfile.NamedTemporaryFile()
+        self.tmp_output_file = tempfile.NamedTemporaryFile()
+    
+    def test_get_args_cli(self):
+        raise NotImplementedError
+    
+    def test_rebuild_mesh_cli(self):
+
+        test_args = ['rebuild_mesh', 
+                     self.tmp_mesh_file.name,
+                     '-o', self.tmp_output_file.name]
+        
+        # Create files with relevant data for test
+        json_dict_to_file(BASIC_MESH, self.tmp_mesh_file.name)
+
+        with patch.object(sys, 'argv', test_args):
+            rebuild_mesh_cli()
+            
+            orig_mesh  = file_to_json(self.tmp_mesh_file.name)
+            rebuilt_mesh = file_to_json(self.tmp_output_file.name)
+
+            self.assertEqual(orig_mesh, rebuilt_mesh)
+
+    def test_create_mesh_cli(self):
+        test_args = ['create_mesh', 
+                     self.tmp_config_file.name,
+                     '-o', self.tmp_output_file.name]
+        
+        # Create files with relevant data for test
+        json_dict_to_file(BASIC_CONFIG, self.tmp_config_file.name)
+        json_dict_to_file(BASIC_MESH, self.tmp_mesh_file.name)
+
+        with patch.object(sys, 'argv', test_args):
+            create_mesh_cli()
+            
+            orig_mesh  = file_to_json(self.tmp_mesh_file.name)
+            created_mesh = file_to_json(self.tmp_output_file.name)
+
+            self.assertEqual(orig_mesh, created_mesh)
+    
+    def test_export_mesh_cli(self):
+        raise NotImplementedError
+    
+    def test_merge_mesh_cli(self):
+        test_args = ['merge_mesh', 
+                     self.tmp_mesh_file_1.name,
+                     self.tmp_mesh_file_2.name,
+                     '-o', self.tmp_output_file.name]
+        
+        # Create files with relevant data for test
+        json_dict_to_file(BASIC_HALF_MESH_1, self.tmp_mesh_file_1.name)
+        json_dict_to_file(BASIC_HALF_MESH_2, self.tmp_mesh_file_2.name)
+        json_dict_to_file(BASIC_MERGED_MESH, self.tmp_mesh_file.name)
+        
+        with patch.object(sys, 'argv', test_args):
+            merge_mesh_cli()
+            
+            orig_mesh  = file_to_json(self.tmp_mesh_file.name)
+            created_mesh = file_to_json(self.tmp_output_file.name)
+
+            self.assertEqual(orig_mesh, created_mesh)
+        
+    def test_meshiphi_test_cli(self):
+        raise NotImplementedError

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -9,7 +9,6 @@ from meshiphi.cli import meshiphi_test_cli
 import tempfile
 import sys
 import unittest
-import warnings
 import json
 from unittest.mock import patch
 
@@ -74,7 +73,12 @@ class TestCLI (unittest.TestCase):
         self.tmp_output_file.close()
     
     def test_get_args_cli(self):
-        warnings.warn("Unit test not implemented, skipping")
+        # TODO:
+        #   - Set up arbitrary arguments to patch into sys.argv
+        #   - Test that argparser correctly ID's these arguments
+        #       - Should have entries for each possible combination of arguments,
+        #         so should be updated whenever CLI is updated
+        pass
     
     def test_rebuild_mesh_cli(self):
         # Command line entry
@@ -122,8 +126,14 @@ class TestCLI (unittest.TestCase):
             self.assertEqual(orig_mesh, created_mesh)
     
     def test_export_mesh_cli(self):
-        warnings.warn("Unit test not implemented, skipping")
-    
+        # TODO:
+        #   - Test GeoJSON output
+        #   - Set up method for comparing PNG and test
+        #       - Also allow PNG creation of empty mesh?
+        #   - Fix TIF export on Windows
+        #   - Set up method for comparing TIF and test
+        pass
+
     def test_merge_mesh_cli(self):
         # Command line entry
         test_args = ['merge_mesh', 
@@ -150,4 +160,9 @@ class TestCLI (unittest.TestCase):
             self.assertEqual(orig_mesh, created_mesh)
         
     def test_meshiphi_test_cli(self):
-        warnings.warn("Unit test not implemented, skipping")
+        # TODO:
+        #  - Set up method for comparing SVG images
+        #  - Compare output json, create BASIC_REG_TEST_OUTPUT constant as ground truth
+        #       - And come up with way to consistently test this with only changes to
+        #         cli.py
+        pass

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -8,15 +8,14 @@ from meshiphi.cli import meshiphi_test_cli
 
 import tempfile
 import sys
-import shutil
 import unittest
-import filecmp
-import difflib
+import warnings
 import json
 from unittest.mock import patch
 
 
 # Contents of JSON files to run through each CLI command with
+# These JSONS are basically configs/meshes with no data
 # Config to create BASIC_OUTPUT
 BASIC_CONFIG = {"region":{"lat_min":-10,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}
 # Mesh to rebuild to create BASIC_OUTPUT
@@ -27,11 +26,28 @@ BASIC_HALF_MESH_1 = {"config":{"mesh_info":{"region":{"lat_min":-10,"lat_max":0,
 BASIC_HALF_MESH_2 = {"config":{"mesh_info":{"region":{"lat_min":0,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}},"cellboxes":[{"geometry":"POLYGON ((-10 0, -10 10, 0 10, 0 0, -10 0))","cx":-5,"cy":5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))","cx":5,"cy":5,"dcx":5,"dcy":5,"id":"1"}],"neighbour_graph":{"0":{"1":[],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[],"-4":[]}}}
 BASIC_MERGED_MESH = {"config":{"mesh_info":{"region":{"lat_min":-10,"lat_max":0,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5},"merged":[{"region":{"lat_min":0,"lat_max":10,"long_min":-10,"long_max":10,"start_time":"2000-01-01","end_time":"2000-12-31","cell_width":10,"cell_height":10},"data_sources":[],"splitting":{"split_depth":1,"minimum_datapoints":5}}]}},"cellboxes":[{"geometry":"POLYGON ((-10 -10, -10 0, 0 0, 0 -10, -10 -10))","cx":-5,"cy":-5,"dcx":5,"dcy":5,"id":"0"},{"geometry":"POLYGON ((0 -10, 0 0, 10 0, 10 -10, 0 -10))","cx":5,"cy":-5,"dcx":5,"dcy":5,"id":"1"},{"geometry":"POLYGON ((-10 0, -10 10, 0 10, 0 0, -10 0))","cx":-5,"cy":5,"dcx":5,"dcy":5,"id":"2"},{"geometry":"POLYGON ((0 0, 0 10, 10 10, 10 0, 0 0))","cx":5,"cy":5,"dcx":5,"dcy":5,"id":"3"}],"neighbour_graph":{"0":{"1":[3],"2":[1],"3":[],"4":[],"-1":[],"-2":[],"-3":[],"-4":[2]},"1":{"1":[],"2":[],"3":[],"4":[],"-1":[],"-2":[0],"-3":[2],"-4":[3]},"2":{"1":[],"2":[3],"3":[1],"4":[0],"-1":[],"-2":[],"-3":[],"-4":[]},"3":{"1":[],"2":[],"3":[],"4":[1],"-1":[0],"-2":[2],"-3":[],"-4":[]}}}
 
+
 def json_dict_to_file(json_dict, filename):
+    """
+    Converts a dictionary to a JSON formatted file
+
+    Args:
+        json_dict (dict): Dict to write to JSON
+        filename (str): Path to file being written
+    """
     with open(filename, 'w') as fp:
         json.dump(json_dict, fp, indent=4)
 
-def file_to_json(filename):
+def file_to_json_dict(filename):
+    """
+    Reads in a JSON file and returns dict of contents
+
+    Args:
+        filename (str): Path to file to be read
+
+    Returns:
+        dict: Dictionary with JSON contents
+    """
     with open(filename, 'r') as fp:
         json_dict = json.load(fp)
     return json_dict
@@ -39,6 +55,7 @@ def file_to_json(filename):
 class TestCLI (unittest.TestCase):
 
     def setUp(self):
+        # Create temporary files to write into 
         self.output_base_directory = tempfile.mkdtemp()
         self.tmp_config_file = tempfile.NamedTemporaryFile()
         self.tmp_mesh_file   = tempfile.NamedTemporaryFile()
@@ -48,6 +65,7 @@ class TestCLI (unittest.TestCase):
         self.tmp_output_file = tempfile.NamedTemporaryFile()
 
     def tearDown(self):
+        # Remove temporary files upon test completion
         self.tmp_config_file.close()
         self.tmp_mesh_file.close()
         self.tmp_mesh_file_1.close()
@@ -56,10 +74,10 @@ class TestCLI (unittest.TestCase):
         self.tmp_output_file.close()
     
     def test_get_args_cli(self):
-        raise NotImplementedError
+        warnings.warn("Unit test not implemented, skipping")
     
     def test_rebuild_mesh_cli(self):
-
+        # Command line entry
         test_args = ['rebuild_mesh', 
                      self.tmp_mesh_file.name,
                      '-o', self.tmp_output_file.name]
@@ -67,15 +85,21 @@ class TestCLI (unittest.TestCase):
         # Create files with relevant data for test
         json_dict_to_file(BASIC_MESH, self.tmp_mesh_file.name)
 
+        # Patch sys.argv with command line entry defined above
         with patch.object(sys, 'argv', test_args):
+
+            # Run the command
             rebuild_mesh_cli()
             
-            orig_mesh  = file_to_json(self.tmp_mesh_file.name)
-            rebuilt_mesh = file_to_json(self.tmp_output_file.name)
+            # Save ground truth and new mesh to JSON dicts
+            orig_mesh  = file_to_json_dict(self.tmp_mesh_file.name)
+            rebuilt_mesh = file_to_json_dict(self.tmp_output_file.name)
 
+            # Ensure they are the same
             self.assertEqual(orig_mesh, rebuilt_mesh)
 
     def test_create_mesh_cli(self):
+        # Command line entry
         test_args = ['create_mesh', 
                      self.tmp_config_file.name,
                      '-o', self.tmp_output_file.name]
@@ -84,18 +108,24 @@ class TestCLI (unittest.TestCase):
         json_dict_to_file(BASIC_CONFIG, self.tmp_config_file.name)
         json_dict_to_file(BASIC_MESH, self.tmp_mesh_file.name)
 
+        # Patch sys.argv with command line entry defined above
         with patch.object(sys, 'argv', test_args):
+
+            # Run the command
             create_mesh_cli()
             
-            orig_mesh  = file_to_json(self.tmp_mesh_file.name)
-            created_mesh = file_to_json(self.tmp_output_file.name)
+            # Save ground truth and new mesh to JSON dicts
+            orig_mesh  = file_to_json_dict(self.tmp_mesh_file.name)
+            created_mesh = file_to_json_dict(self.tmp_output_file.name)
 
+            # Ensure they are the same
             self.assertEqual(orig_mesh, created_mesh)
     
     def test_export_mesh_cli(self):
-        raise NotImplementedError
+        warnings.warn("Unit test not implemented, skipping")
     
     def test_merge_mesh_cli(self):
+        # Command line entry
         test_args = ['merge_mesh', 
                      self.tmp_mesh_file_1.name,
                      self.tmp_mesh_file_2.name,
@@ -106,13 +136,18 @@ class TestCLI (unittest.TestCase):
         json_dict_to_file(BASIC_HALF_MESH_2, self.tmp_mesh_file_2.name)
         json_dict_to_file(BASIC_MERGED_MESH, self.tmp_mesh_file.name)
         
+        # Patch sys.argv with command line entry defined above
         with patch.object(sys, 'argv', test_args):
+
+            # Run the command
             merge_mesh_cli()
             
-            orig_mesh  = file_to_json(self.tmp_mesh_file.name)
-            created_mesh = file_to_json(self.tmp_output_file.name)
+            # Save ground truth and new mesh to JSON dicts
+            orig_mesh  = file_to_json_dict(self.tmp_mesh_file.name)
+            created_mesh = file_to_json_dict(self.tmp_output_file.name)
 
+            # Ensure they are the same
             self.assertEqual(orig_mesh, created_mesh)
         
     def test_meshiphi_test_cli(self):
-        raise NotImplementedError
+        warnings.warn("Unit test not implemented, skipping")

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -8,6 +8,7 @@ from meshiphi.cli import meshiphi_test_cli
 
 import tempfile
 import sys
+import shutil
 import unittest
 import filecmp
 import difflib
@@ -45,6 +46,14 @@ class TestCLI (unittest.TestCase):
         self.tmp_mesh_file_2 = tempfile.NamedTemporaryFile()
         self.tmp_merge_file  = tempfile.NamedTemporaryFile()
         self.tmp_output_file = tempfile.NamedTemporaryFile()
+
+    def tearDown(self):
+        self.tmp_config_file.close()
+        self.tmp_mesh_file.close()  
+        self.tmp_mesh_file_1.close()    
+        self.tmp_mesh_file_2.close()    
+        self.tmp_merge_file.close() 
+        self.tmp_output_file.close()    
     
     def test_get_args_cli(self):
         raise NotImplementedError


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-06-13
Version Number: 2.1.10
 
## Description of change
Added some unit tests for cli.py.
I've not complied with PEP-8 by storing the 'ground truth' JSON dicts as one-line entries, so as to not clutter the rest of the `test_cli.py` file.  

This test suite is incomplete for various reasons, but the major methods are covered.

- `get_args_cli` is not tested since it folds into all of the other methods, and isn't straightforward to test by itself

- `export_mesh_cli` is not tested as it generates files with a fixed name/path which would clutter the working directory of anyone running the tests. It also outputs files that are not easily comparable (PNG, TIF) without storing extra files in the tests directory (but I could do that if requested). Finally, the TIF output is broken anyway because of GDAL issues (see  #27).

- `meshiphi_test_cli` is not tested for similar reasons to `export_mesh_cli`. 


# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy

- [ ] My changes result in all required regression tests passing without the need to update test files.  

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   


# Checklist

- [] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
