### PR TITLE
Test neighbour graph

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.10"
+__version__ = "2.1.11"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -434,7 +434,16 @@ class TestNeighbourGraph (unittest.TestCase):
                          0)
     
     def test_remove_neighbour(self):
-        raise NotImplementedError
+        # Create a new neighbourgraph to edit freely
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        # Remove element 3 from the NE direction of cb 5 in the neighbourgraph
+        ng.remove_neighbour(5, Direction.north_east, 3)
+
+        # Do this again by manually editing the neighbourgraph
+        manually_adjusted_ng = copy.deepcopy(self.ng_dict_3x3)
+        manually_adjusted_ng[5][Direction.north_east] = []
+
+        self.assertEqual(ng.get_graph(), manually_adjusted_ng)
     
     def test_initialise_neighbour_graph(self):
         raise NotImplementedError

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -9,7 +9,6 @@ from meshiphi.mesh_generation.cellbox import CellBox
 
 from meshiphi.mesh_generation.boundary import Boundary
 
-
 def create_ng_from_dict(ng_dict, global_mesh=False):
     ng = NeighbourGraph()
     ng.neighbour_graph = copy.deepcopy(ng_dict)
@@ -168,7 +167,64 @@ class TestNeighbourGraph (unittest.TestCase):
         raise NotImplementedError
     
     def test_get_neighbour_case_bounds(self):
-        raise NotImplementedError
+
+        # Set base boundary
+        lat_range = [-10, 10]
+        long_range = [-10, 10]
+
+        base_bounds  = Boundary(lat_range, long_range)
+
+        # Initialise a neighbourgraph object to get access to get_neighbour_case_bounds()
+        ng = NeighbourGraph()
+
+        # Define which direction each cardinal direction lies
+        northern_directions  = [Direction.north_east, Direction.north, Direction.north_west]
+        eastern_directions   = [Direction.north_east, Direction.east,  Direction.south_east]
+        southern_directions  = [Direction.south_east, Direction.south, Direction.south_west]
+        western_directions   = [Direction.south_west, Direction.west,  Direction.north_west]
+        all_directions = [Direction.north, Direction.north_east,
+                          Direction.east,  Direction.south_east,
+                          Direction.south, Direction.south_west,
+                          Direction.west,  Direction.north_west]
+        
+        for direction in all_directions:
+            # Offset a second boundary object depending on which direction is being tested
+            if direction in northern_directions:
+                lat_offset = 20
+            elif direction in southern_directions:
+                lat_offset = -20
+            
+            if direction in eastern_directions:
+                long_offset = 20
+            elif direction in western_directions:
+                long_offset = -20
+
+            # Add offsets to base boundary and create new boundary object
+            offset_lat_range = [lat + lat_offset for lat in lat_range]
+            offset_long_range = [long + long_offset for long in long_range]
+
+            offset_bounds = Boundary(offset_lat_range, offset_long_range)
+
+            # Make sure it returns the correct case
+            self.assertEqual(ng.get_neighbour_case_bounds(base_bounds, 
+                                                          offset_bounds), 
+                             direction)
+        
+        # Final test: make sure that two boundaries that don't touch return an invalid direction (0)
+        lat_offset = 100
+        long_offset = 100
+        # Add offsets to base boundary and create new boundary object
+        offset_lat_range = [lat + lat_offset for lat in lat_range]
+        offset_long_range = [long + long_offset for long in long_range]
+
+        offset_bounds = Boundary(offset_lat_range, offset_long_range)
+
+        # Make sure it returns the correct case
+        self.assertEqual(ng.get_neighbour_case_bounds(base_bounds, 
+                                                        offset_bounds), 
+                         0)
+
+
     
     def test_get_neighbour_case(self):
         raise NotImplementedError

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -169,11 +169,64 @@ class TestNeighbourGraph (unittest.TestCase):
         self.assertEqual(ng.get_graph(), manually_removed_ng_dict)
     
     def test_update_neighbours(self):
-        ## I think there's a bug in remove_node_in_neighbours
-        raise NotImplementedError
-        
-        
-    
+        # Initialise a new neighbour graph to modify
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        # Initial CB layout that matches ng
+        cbs = [
+            CellBox(Boundary([2,3],[0,1]), 1), CellBox(Boundary([2,3],[1,2]), 2), CellBox(Boundary([2,3],[2,3]), 3),
+            CellBox(Boundary([1,2],[0,1]), 4), CellBox(Boundary([1,2],[1,2]), 5), CellBox(Boundary([1,2],[2,3]), 6),
+            CellBox(Boundary([0,1],[0,1]), 7), CellBox(Boundary([0,1],[1,2]), 8), CellBox(Boundary([0,1],[2,3]), 9),
+        ]
+
+        # Creates the cellboxes that the centre cellbox would become when split
+        split_cbs = [
+            CellBox(Boundary([1.5,2],[1,1.5]), 51),
+            CellBox(Boundary([1.5,2],[1.5,2]), 53),
+            CellBox(Boundary([1,1.5],[1,1.5]), 57),
+            CellBox(Boundary([1,1.5],[1.5,2]), 59),
+        ]
+
+        # Cast to a list so that indexes match up with indexes (using index as key essentially)
+        all_cbs = {cb.id: cb for cb in cbs + split_cbs}
+
+        # Original cellbox from neighbour graph
+        unsplit_cb_idx = 5
+
+        # Indexes of split cellboxes 
+        north_split_cb_idxs = [51, 53]
+        east_split_cb_idxs  = [53, 59]
+        south_split_cb_idxs = [57, 59]
+        west_split_cb_idxs  = [51, 57]
+
+        # Update the neighbourgraph with the new split cellbox ids
+        ng.update_neighbours(unsplit_cb_idx, north_split_cb_idxs, Direction.north, all_cbs)
+        ng.update_neighbours(unsplit_cb_idx, east_split_cb_idxs,  Direction.east,  all_cbs)
+        ng.update_neighbours(unsplit_cb_idx, south_split_cb_idxs, Direction.south, all_cbs)
+        ng.update_neighbours(unsplit_cb_idx, west_split_cb_idxs,  Direction.west,  all_cbs)
+
+        # Create this neighbourgraph manually
+        manually_adjusted_ng = copy.deepcopy(self.ng_dict_3x3)
+        manually_adjusted_ng[2][Direction.south] = north_split_cb_idxs
+        manually_adjusted_ng[4][Direction.east]  = west_split_cb_idxs
+        manually_adjusted_ng[6][Direction.west]  = east_split_cb_idxs
+        manually_adjusted_ng[8][Direction.north] = south_split_cb_idxs
+
+        # Final neighbourgraph should look like
+        #
+        #    1 |    2    | 3
+        #    --+---------+---
+        #      | 51 | 53 |
+        #    4 |---------| 6
+        #      | 57 | 59 |  
+        #   ---+---------+---
+        #    7 |    8    | 9
+        #   
+
+        self.assertEqual(ng.get_graph()[2], manually_adjusted_ng[2])
+        self.assertEqual(ng.get_graph()[4], manually_adjusted_ng[4])
+        self.assertEqual(ng.get_graph()[6], manually_adjusted_ng[6])
+        self.assertEqual(ng.get_graph()[8], manually_adjusted_ng[8])
+
     def test_remove_node_from_neighbours(self):
         # Create a new neighbour graph to edit freely
         ng = create_ng_from_dict(self.ng_dict_3x3)

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -8,77 +8,146 @@ from meshiphi.mesh_generation.cellbox import CellBox
 
 from meshiphi.mesh_generation.boundary import Boundary
 class TestNeighbourGraph (unittest.TestCase):
-   def setUp(self):
-         boundary = Boundary([-85,-80], [-135,-130], ['1970-01-01','2021-12-31'])
-         cellbox = CellBox (boundary , 0)
-         params = {
-      'file': '../../datastore/bathymetry/GEBCO/gebco_2022_n-40.0_s-90.0_w-140.0_e0.0.nc',
-		'downsample_factors': (5,5),
-		'data_name': 'elevation',
-		'aggregate_type': 'MAX',
-       'value_fill_types': "parent"
-         }
-         split_conds = {
-	'threshold': 620,
-	'upper_bound': 0.9,
-	'lower_bound': 0.1
-	}
+    
+    def setUp(self):
+        pass
+
+    def test_from_json(self):
+        raise NotImplementedError
+    
+    def test_increment_ids(self):
+        raise NotImplementedError
+    
+    def test_get_graph(self):
+        raise NotImplementedError
+    
+    def test_update_neighbour(self):
+        raise NotImplementedError
+    
+    def test_add_neighbour(self):
+        raise NotImplementedError
+    
+    def test_remove_node_and_update_neighbours(self):
+        raise NotImplementedError
+    
+    def test_get_neighbours(self):
+        raise NotImplementedError
+    
+    def test_add_node(self):
+        raise NotImplementedError
+    
+    def test_remove_node(self):
+        raise NotImplementedError
+    
+    def test_update_neighbours(self):
+        raise NotImplementedError
+    
+    def test_remove_node_from_neighbours(self):
+        raise NotImplementedError
+    
+    def test_update_corner_neighbours(self):
+        raise NotImplementedError
+    
+    def test_get_neighbour_case_bounds(self):
+        raise NotImplementedError
+    
+    def test_get_neighbour_case(self):
+        raise NotImplementedError
+    
+    def test_get_global_mesh_neighbour_case(self):
+        raise NotImplementedError
+    
+    def test_remove_neighbour(self):
+        raise NotImplementedError
+    
+    def test_initialise_neighbour_graph(self):
+        raise NotImplementedError
+    
+    def test_initialise_map(self):
+        raise NotImplementedError
+    
+    def test_set_global_mesh(self):
+        raise NotImplementedError
+    
+    def test_is_global_mesh(self):
+        raise NotImplementedError
+    
+    def test_get_neighbour_map(self):
+        raise NotImplementedError
+
+
+
+   # def setUp(self):
+   #       boundary = Boundary([-85,-80], [-135,-130], ['1970-01-01','2021-12-31'])
+   #       cellbox = CellBox (boundary , 0)
+   #       params = {
+   #    'file': '../../datastore/bathymetry/GEBCO/gebco_2022_n-40.0_s-90.0_w-140.0_e0.0.nc',
+	# 	'downsample_factors': (5,5),
+	# 	'data_name': 'elevation',
+	# 	'aggregate_type': 'MAX',
+   #     'value_fill_types': "parent"
+   #       }
+   #       split_conds = {
+	# 'threshold': 620,
+	# 'upper_bound': 0.9,
+	# 'lower_bound': 0.1
+	# }
         
-         gebco = DataLoaderFactory().get_dataloader('GEBCO', boundary , params, min_dp = 5)
-         cellbox.set_data_source ([Metadata (gebco , [split_conds] ,  params ['value_fill_types'])])
-         self.cellboxes = cellbox.split(0)
-         cell_width = 2.5
-         grid_width = (boundary.get_long_max() - boundary.get_long_min()) / cell_width
-         self.neighbour_graph = NeighbourGraph (self.cellboxes ,grid_width )
+   #       gebco = DataLoaderFactory().get_dataloader('GEBCO', boundary , params, min_dp = 5)
+   #       cellbox.set_data_source ([Metadata (gebco , [split_conds] ,  params ['value_fill_types'])])
+   #       self.cellboxes = cellbox.split(0)
+   #       cell_width = 2.5
+   #       grid_width = (boundary.get_long_max() - boundary.get_long_min()) / cell_width
+   #       self.neighbour_graph = NeighbourGraph (self.cellboxes ,grid_width )
          
 
-   def test_initialize_NG(self):
-      self.assertEqual ( 4 , len (self.neighbour_graph.get_graph()))
-      self.assertEqual ( {1: [3], 2: [1], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
-      self.assertEqual ( {1: [], 2: [], 3: [], 4: [], -1: [], -2: [0], -3: [2], -4: [3]} , self.neighbour_graph.get_graph()[1]) # NE cellbox
-      self.assertEqual ( {1: [], 2: [3], 3: [1], 4: [0], -1: [], -2: [], -3: [], -4: []} , self.neighbour_graph.get_graph()[2]) # SW cellbox
-      self.assertEqual ( {1: [], 2: [], 3: [], 4: [1], -1: [0], -2: [2], -3: [], -4: []} , self.neighbour_graph.get_graph()[3]) # SE cellbox
+   # def test_initialize_NG(self):
+   #    self.assertEqual ( 4 , len (self.neighbour_graph.get_graph()))
+   #    self.assertEqual ( {1: [3], 2: [1], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
+   #    self.assertEqual ( {1: [], 2: [], 3: [], 4: [], -1: [], -2: [0], -3: [2], -4: [3]} , self.neighbour_graph.get_graph()[1]) # NE cellbox
+   #    self.assertEqual ( {1: [], 2: [3], 3: [1], 4: [0], -1: [], -2: [], -3: [], -4: []} , self.neighbour_graph.get_graph()[2]) # SW cellbox
+   #    self.assertEqual ( {1: [], 2: [], 3: [], 4: [1], -1: [0], -2: [2], -3: [], -4: []} , self.neighbour_graph.get_graph()[3]) # SE cellbox
 
    
-   def test_remove_neighbour (self):
-      self.neighbour_graph.remove_neighbour(0 ,  Direction.east , 1)
-      self.assertEqual ( {1: [3], 2: [], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
-      self.neighbour_graph.update_neighbour(0 , Direction.east , [1]) # undo the remove
+   # def test_remove_neighbour (self):
+   #    self.neighbour_graph.remove_neighbour(0 ,  Direction.east , 1)
+   #    self.assertEqual ( {1: [3], 2: [], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
+   #    self.neighbour_graph.update_neighbour(0 , Direction.east , [1]) # undo the remove
 
-   def test_update_neighbour (self):
-      self.neighbour_graph.update_neighbour(0 ,  Direction.south_east , [3])
-      self.assertEqual ( {1: [3], 2: [1], 3: [3], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
-      self.neighbour_graph.remove_neighbour(0 ,  Direction.south_east , 3)# undo the update
+   # def test_update_neighbour (self):
+   #    self.neighbour_graph.update_neighbour(0 ,  Direction.south_east , [3])
+   #    self.assertEqual ( {1: [3], 2: [1], 3: [3], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
+   #    self.neighbour_graph.remove_neighbour(0 ,  Direction.south_east , 3)# undo the update
   
-   def test_get_neighbour_case(self):
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[1])
-      self.assertEqual ( 2, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[2])
-      self.assertEqual ( 4, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[3])
-      self.assertEqual (3 , case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[2] , self.cellboxes[0])
-      self.assertEqual ( -4, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[1] , self.cellboxes[2])
-      self.assertEqual ( -1, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[2] , self.cellboxes[1])
-      self.assertEqual ( 1, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[0])
-      self.assertEqual ( -3, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[2])
-      self.assertEqual ( -2, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[1])
-      self.assertEqual ( -4, case)
-      case = self.neighbour_graph.get_neighbour_case(self.cellboxes[1] , self.cellboxes[3])
-      self.assertEqual ( 4, case)
+   # def test_get_neighbour_case(self):
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[1])
+   #    self.assertEqual ( 2, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[2])
+   #    self.assertEqual ( 4, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[3])
+   #    self.assertEqual (3 , case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[2] , self.cellboxes[0])
+   #    self.assertEqual ( -4, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[1] , self.cellboxes[2])
+   #    self.assertEqual ( -1, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[2] , self.cellboxes[1])
+   #    self.assertEqual ( 1, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[0])
+   #    self.assertEqual ( -3, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[2])
+   #    self.assertEqual ( -2, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[1])
+   #    self.assertEqual ( -4, case)
+   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[1] , self.cellboxes[3])
+   #    self.assertEqual ( 4, case)
 
-   def test_update_neighbours (self):
-      self.neighbour_graph.update_neighbours(0, [2,1], Direction.north_east, self.cellboxes)
-      self.assertEqual (  {1: [], 2: [], 3: [], 4: [1], -1: [], -2: [2,2], -3: [], -4: [1]} , self.neighbour_graph.get_graph()[3]) # SE cellbox
-      self.neighbour_graph.update_neighbour(3, Direction.south, [1]) # undo the first update 
-      self.neighbour_graph.update_neighbour(3, Direction.west, [2]) # undo the first update 
-      self.neighbour_graph.update_neighbour(3, Direction.north, []) # undo the first update 
+   # def test_update_neighbours (self):
+   #    self.neighbour_graph.update_neighbours(0, [2,1], Direction.north_east, self.cellboxes)
+   #    self.assertEqual (  {1: [], 2: [], 3: [], 4: [1], -1: [], -2: [2,2], -3: [], -4: [1]} , self.neighbour_graph.get_graph()[3]) # SE cellbox
+   #    self.neighbour_graph.update_neighbour(3, Direction.south, [1]) # undo the first update 
+   #    self.neighbour_graph.update_neighbour(3, Direction.west, [2]) # undo the first update 
+   #    self.neighbour_graph.update_neighbour(3, Direction.north, []) # undo the first update 
   
-   def test_update_corner_neighbours(self):
-      self.neighbour_graph.update_corner_neighbours (3 , -1, -1, -1, -1 )
-      self.assertEqual ( {1: [-1], 2: [1], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # SE cellbox
+   # def test_update_corner_neighbours(self):
+   #    self.neighbour_graph.update_corner_neighbours (3 , -1, -1, -1, -1 )
+   #    self.assertEqual ( {1: [-1], 2: [1], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # SE cellbox

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -9,6 +9,18 @@ from meshiphi.mesh_generation.cellbox import CellBox
 
 from meshiphi.mesh_generation.boundary import Boundary
 
+
+# Define which direction each cardinal direction lies
+NORTHERN_DIRECTIONS  = [Direction.north_east, Direction.north, Direction.north_west]
+EASTERN_DIRECTIONS   = [Direction.north_east, Direction.east,  Direction.south_east]
+SOUTHERN_DIRECTIONS  = [Direction.south_east, Direction.south, Direction.south_west]
+WESTERN_DIRECTIONS   = [Direction.south_west, Direction.west,  Direction.north_west]
+ALL_DIRECTIONS = [Direction.north, Direction.north_east,
+                    Direction.east,  Direction.south_east,
+                    Direction.south, Direction.south_west,
+                    Direction.west,  Direction.north_west]
+
+
 def create_ng_from_dict(ng_dict, global_mesh=False):
     ng = NeighbourGraph()
     ng.neighbour_graph = copy.deepcopy(ng_dict)
@@ -176,27 +188,17 @@ class TestNeighbourGraph (unittest.TestCase):
 
         # Initialise a neighbourgraph object to get access to get_neighbour_case_bounds()
         ng = NeighbourGraph()
-
-        # Define which direction each cardinal direction lies
-        northern_directions  = [Direction.north_east, Direction.north, Direction.north_west]
-        eastern_directions   = [Direction.north_east, Direction.east,  Direction.south_east]
-        southern_directions  = [Direction.south_east, Direction.south, Direction.south_west]
-        western_directions   = [Direction.south_west, Direction.west,  Direction.north_west]
-        all_directions = [Direction.north, Direction.north_east,
-                          Direction.east,  Direction.south_east,
-                          Direction.south, Direction.south_west,
-                          Direction.west,  Direction.north_west]
-        
-        for direction in all_directions:
+       
+        for direction in ALL_DIRECTIONS:
             # Offset a second boundary object depending on which direction is being tested
-            if direction in northern_directions:
+            if direction in NORTHERN_DIRECTIONS:
                 lat_offset = 20
-            elif direction in southern_directions:
+            elif direction in SOUTHERN_DIRECTIONS:
                 lat_offset = -20
             
-            if direction in eastern_directions:
+            if direction in EASTERN_DIRECTIONS:
                 long_offset = 20
-            elif direction in western_directions:
+            elif direction in WESTERN_DIRECTIONS:
                 long_offset = -20
 
             # Add offsets to base boundary and create new boundary object
@@ -211,8 +213,8 @@ class TestNeighbourGraph (unittest.TestCase):
                              direction)
         
         # Final test: make sure that two boundaries that don't touch return an invalid direction (0)
-        lat_offset = 100
-        long_offset = 100
+        lat_offset = 50
+        long_offset = 50
         # Add offsets to base boundary and create new boundary object
         offset_lat_range = [lat + lat_offset for lat in lat_range]
         offset_long_range = [long + long_offset for long in long_range]
@@ -224,10 +226,58 @@ class TestNeighbourGraph (unittest.TestCase):
                                                         offset_bounds), 
                          0)
 
-
-    
     def test_get_neighbour_case(self):
-        raise NotImplementedError
+        # Not testing global boundary case here because that's tested in 
+        # test_get_global_mesh_neighbour_case
+
+        # Set base boundary
+        lat_range = [-10, 10]
+        long_range = [-10, 10]
+
+        base_bounds  = Boundary(lat_range, long_range)
+        base_cellbox = CellBox(base_bounds, 0)
+
+        # Initialise a neighbourgraph object to get access to get_neighbour_case_bounds()
+        ng = NeighbourGraph()
+        
+        for direction in ALL_DIRECTIONS:
+            # Offset a second boundary object depending on which direction is being tested
+            if direction in NORTHERN_DIRECTIONS:
+                lat_offset = 20
+            elif direction in SOUTHERN_DIRECTIONS:
+                lat_offset = -20
+            
+            if direction in EASTERN_DIRECTIONS:
+                long_offset = 20
+            elif direction in WESTERN_DIRECTIONS:
+                long_offset = -20
+
+            # Add offsets to base boundary and create new boundary object
+            offset_lat_range = [lat + lat_offset for lat in lat_range]
+            offset_long_range = [long + long_offset for long in long_range]
+
+            offset_bounds = Boundary(offset_lat_range, offset_long_range)
+            offset_cellbox = CellBox(offset_bounds, 1)
+
+            # Make sure it returns the correct case
+            self.assertEqual(ng.get_neighbour_case(base_cellbox, 
+                                                   offset_cellbox), 
+                             direction)
+        
+        # Final test: make sure that two boundaries that don't touch return an invalid direction (0)
+        lat_offset = 50
+        long_offset = 50
+        # Add offsets to base boundary and create new boundary object
+        offset_lat_range = [lat + lat_offset for lat in lat_range]
+        offset_long_range = [long + long_offset for long in long_range]
+
+        offset_bounds = Boundary(offset_lat_range, offset_long_range)
+        offset_cellbox = CellBox(offset_bounds, 1)
+
+        # Make sure it returns the correct case
+        self.assertEqual(ng.get_neighbour_case(base_cellbox, 
+                                               offset_cellbox), 
+                         0)
     
     def test_get_global_mesh_neighbour_case(self):
         raise NotImplementedError

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -50,16 +50,6 @@ class TestNeighbourGraph (unittest.TestCase):
                             7: {1: [5], 2: [8], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [4]},
                             8: {1: [6], 2: [9], 3: [ ], 4: [ ], -1: [ ], -2: [7], -3: [4], -4: [5]},
                             9: {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [8], -3: [5], -4: [6]}}
-
-        # self.ng_dict_3x3 = {1: {"1": [ ], "2": [2], "3": [5], "4": [4], "-1": [ ], "-2": [ ], "-3": [ ], "-4": [ ]},
-        #                     2: {"1": [ ], "2": [3], "3": [6], "4": [5], "-1": [4], "-2": [1], "-3": [ ], "-4": [ ]},
-        #                     3: {"1": [ ], "2": [ ], "3": [ ], "4": [6], "-1": [5], "-2": [2], "-3": [ ], "-4": [ ]},
-        #                     4: {"1": [2], "2": [5], "3": [8], "4": [7], "-1": [ ], "-2": [ ], "-3": [ ], "-4": [1]},
-        #                     5: {"1": [3], "2": [6], "3": [9], "4": [8], "-1": [7], "-2": [4], "-3": [1], "-4": [2]},
-        #                     6: {"1": [ ], "2": [ ], "3": [ ], "4": [9], "-1": [8], "-2": [5], "-3": [2], "-4": [3]},
-        #                     7: {"1": [5], "2": [8], "3": [ ], "4": [ ], "-1": [ ], "-2": [ ], "-3": [ ], "-4": [4]},
-        #                     8: {"1": [6], "2": [9], "3": [ ], "4": [ ], "-1": [ ], "-2": [7], "-3": [4], "-4": [5]},
-        #                     9: {"1": [ ], "2": [ ], "3": [ ], "4": [ ], "-1": [ ], "-2": [8], "-3": [5], "-4": [6]}}
         
         # Non-global 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
         self.arbitrary_neighbour_graph = create_ng_from_dict(self.ng_dict_3x3)
@@ -67,7 +57,6 @@ class TestNeighbourGraph (unittest.TestCase):
         # 1x2 Neighbour graph, oriented E-W
         self.antimeridian_neighbour_graph = {"1":{1: [ ], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
                                              "2":{1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [1], -3: [ ], -4: [ ]}}
-
 
     def test_from_json(self):
 
@@ -148,7 +137,6 @@ class TestNeighbourGraph (unittest.TestCase):
 
         self.assertEqual(ng.get_graph(), manually_removed_ng_dict)
 
-    
     def test_get_neighbours(self):
 
         for cb_index in self.ng_dict_3x3.keys():
@@ -183,10 +171,30 @@ class TestNeighbourGraph (unittest.TestCase):
     def test_update_neighbours(self):
         ## I think there's a bug in remove_node_in_neighbours
         raise NotImplementedError
+        
+        
     
     def test_remove_node_from_neighbours(self):
-        ## I think there's a bug in remove_node_in_neighbours
-        raise NotImplementedError
+        # Create a new neighbour graph to edit freely
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        # Make a copy of the neighbourgraph to edit freely
+        manually_adjusted_ng = copy.deepcopy(self.ng_dict_3x3)
+
+        # In each direction, remove the central node
+        for direction in ALL_DIRECTIONS:
+            # Remove node using ng method
+            ng.remove_node_from_neighbours(5, direction)
+            
+            # Manually remove the node
+            # Get index of cellbox in direction
+            neighbour_in_direction = manually_adjusted_ng[5][direction][0]
+            # Get neighbours of that cellbox in the direction of the node to remove (hence the negative direction)
+            neighbour_list = manually_adjusted_ng[neighbour_in_direction][-direction]
+            # Remove central node
+            neighbour_list.pop(neighbour_list.index(5))
+
+            # Compare method copy to manually removed copy
+            self.assertEqual(ng.get_graph(), manually_adjusted_ng)
     
     def test_update_corner_neighbours(self):
 

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -473,8 +473,36 @@ class TestNeighbourGraph (unittest.TestCase):
         self.assertEqual(ng.get_graph(), reference_neighbour_graph)
 
     def test_initialise_map(self):
-        raise NotImplementedError
-    
+        # Initialise a new neighbour graph to modify
+        ng = NeighbourGraph()
+        # Initial CB layout
+        cbs = [
+            CellBox(Boundary([2,3],[0,1]), 1), CellBox(Boundary([2,3],[1,2]), 2), CellBox(Boundary([2,3],[2,3]), 3),
+            CellBox(Boundary([1,2],[0,1]), 4), CellBox(Boundary([1,2],[1,2]), 5), CellBox(Boundary([1,2],[2,3]), 6),
+            CellBox(Boundary([0,1],[0,1]), 7), CellBox(Boundary([0,1],[1,2]), 8), CellBox(Boundary([0,1],[2,3]), 9),
+        ]
+        
+        # Manually define what the output should be
+        reference_neighbour_graph = {
+            0: {1: [4], 2: [1], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [3]}, 
+            1: {1: [5], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [0], -3: [3], -4: [4]}, 
+            2: {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [1], -3: [4], -4: [5]}, 
+            3: {1: [7], 2: [4], 3: [1], 4: [0], -1: [ ], -2: [ ], -3: [ ], -4: [6]}, 
+            4: {1: [8], 2: [5], 3: [2], 4: [1], -1: [0], -2: [3], -3: [6], -4: [7]}, 
+            5: {1: [ ], 2: [ ], 3: [ ], 4: [2], -1: [1], -2: [4], -3: [7], -4: [8]}, 
+            6: {1: [ ], 2: [7], 3: [4], 4: [3], -1: [ ], -2: [ ], -3: [ ], -4: [ ]}, 
+            7: {1: [ ], 2: [8], 3: [5], 4: [4], -1: [3], -2: [6], -3: [ ], -4: [ ]}, 
+            8: {1: [ ], 2: [ ], 3: [ ], 4: [5], -1: [4], -2: [7], -3: [ ], -4: [ ]}
+        }
+
+        # Run through each cellbox and create the neighbour map
+        for cb in cbs:
+            cb_idx = cbs.index(cb)
+            neighbour_map = ng.initialise_map(cb_idx, 3, 9)
+
+            self.assertEqual(neighbour_map, reference_neighbour_graph[cb_idx])
+            
+
     def test_set_global_mesh(self):
         global_ng = create_ng_from_dict(self.ng_dict_3x3,    global_mesh=True)
         nonglobal_ng = create_ng_from_dict(self.ng_dict_3x3, global_mesh=False)

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -52,7 +52,7 @@ class TestNeighbourGraph (unittest.TestCase):
                             9: {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [8], -3: [5], -4: [6]}}
         
         # Non-global 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
-        self.arbitrary_neighbour_graph = create_ng_from_dict(self.ng_dict_3x3)
+        self.neighbour_graph = create_ng_from_dict(self.ng_dict_3x3)
         
         # 1x2 Neighbour graph, oriented E-W
         self.antimeridian_neighbour_graph = {"1":{1: [ ], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
@@ -84,7 +84,7 @@ class TestNeighbourGraph (unittest.TestCase):
 
     def test_get_graph(self):
         
-        ng_dict = self.arbitrary_neighbour_graph.get_graph()
+        ng_dict = self.neighbour_graph.get_graph()
         self.assertEqual(ng_dict, self.ng_dict_3x3)
     
     def test_update_neighbour(self):
@@ -141,7 +141,7 @@ class TestNeighbourGraph (unittest.TestCase):
 
         for cb_index in self.ng_dict_3x3.keys():
             for direction in ALL_DIRECTIONS:
-                ng_neighbours = self.arbitrary_neighbour_graph.get_neighbours(cb_index, direction)
+                ng_neighbours = self.neighbour_graph.get_neighbours(cb_index, direction)
                 self.assertEqual(ng_neighbours, self.ng_dict_3x3[cb_index][direction])
     
     def test_add_node(self):
@@ -446,8 +446,32 @@ class TestNeighbourGraph (unittest.TestCase):
         self.assertEqual(ng.get_graph(), manually_adjusted_ng)
     
     def test_initialise_neighbour_graph(self):
-        raise NotImplementedError
-    
+        # Initialise a new neighbour graph to modify
+        ng = NeighbourGraph()
+        # Initial CB layout
+        cbs = [
+            CellBox(Boundary([2,3],[0,1]), 1), CellBox(Boundary([2,3],[1,2]), 2), CellBox(Boundary([2,3],[2,3]), 3),
+            CellBox(Boundary([1,2],[0,1]), 4), CellBox(Boundary([1,2],[1,2]), 5), CellBox(Boundary([1,2],[2,3]), 6),
+            CellBox(Boundary([0,1],[0,1]), 7), CellBox(Boundary([0,1],[1,2]), 8), CellBox(Boundary([0,1],[2,3]), 9),
+        ]
+        # Create neighbourgraph based on cb list
+        ng.initialise_neighbour_graph(cbs, 3)
+
+        # Manually define what the output should be
+        reference_neighbour_graph = {
+            0: {1: [4], 2: [1], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [3]}, 
+            1: {1: [5], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [0], -3: [3], -4: [4]}, 
+            2: {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [1], -3: [4], -4: [5]}, 
+            3: {1: [7], 2: [4], 3: [1], 4: [0], -1: [ ], -2: [ ], -3: [ ], -4: [6]}, 
+            4: {1: [8], 2: [5], 3: [2], 4: [1], -1: [0], -2: [3], -3: [6], -4: [7]}, 
+            5: {1: [ ], 2: [ ], 3: [ ], 4: [2], -1: [1], -2: [4], -3: [7], -4: [8]}, 
+            6: {1: [ ], 2: [7], 3: [4], 4: [3], -1: [ ], -2: [ ], -3: [ ], -4: [ ]}, 
+            7: {1: [ ], 2: [8], 3: [5], 4: [4], -1: [3], -2: [6], -3: [ ], -4: [ ]}, 
+            8: {1: [ ], 2: [ ], 3: [ ], 4: [5], -1: [4], -2: [7], -3: [ ], -4: [ ]}
+        }
+
+        self.assertEqual(ng.get_graph(), reference_neighbour_graph)
+
     def test_initialise_map(self):
         raise NotImplementedError
     

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -127,30 +127,32 @@ class TestNeighbourGraph (unittest.TestCase):
     
     def test_remove_node_and_update_neighbours(self):
         
-        # node_to_remove = '5'
+        # Remove central (i.e. most connected) node for testing
+        node_to_remove = 5
 
-        # ng = create_ng_from_dict(self.ng_dict_3x3)
-        # ng.remove_node_and_update_neighbours(node_to_remove)
+        # Create a new neighbourgraph
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        # Remove node using ng method
+        ng.remove_node_and_update_neighbours(node_to_remove)
         
-        # manually_removed_ng_dict = copy.deepcopy(self.ng_dict_3x3)
-        # for node, dir_map in manually_removed_ng_dict.items():
-        #     for direction in dir_map.keys():
-        #         if node_to_remove in node[direction]:
-        #             node[direction].pop(node_to_remove)
-        # manually_removed_ng_dict.pop(node_to_remove)
+        # Reconstruct manually to test method works
+        # Create a new neighbour graph
+        manually_removed_ng_dict = copy.deepcopy(self.ng_dict_3x3)
+        # Remove the central node by popping it out of neighbour lists
+        for node, dir_map in manually_removed_ng_dict.items():
+            for direction, neighbours in dir_map.items():
+                if node_to_remove in neighbours:
+                    neighbours.pop(neighbours.index(node_to_remove))
+        # Then remove the central node entirely
+        manually_removed_ng_dict.pop(node_to_remove)
 
-        # self.assertEqual(ng.get_graph(), manually_removed_ng_dict)
+        self.assertEqual(ng.get_graph(), manually_removed_ng_dict)
 
-
-        ## I think there's a bug in remove_node_in_neighbours
-        raise NotImplementedError
     
     def test_get_neighbours(self):
-        dir_obj = Direction()
 
         for cb_index in self.ng_dict_3x3.keys():
-            for direction in dir_obj.__dict__.values():
-                direction = direction
+            for direction in ALL_DIRECTIONS:
                 ng_neighbours = self.arbitrary_neighbour_graph.get_neighbours(cb_index, direction)
                 self.assertEqual(ng_neighbours, self.ng_dict_3x3[cb_index][direction])
     

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -16,6 +16,7 @@ NORTHERN_DIRECTIONS  = [Direction.north_east, Direction.north, Direction.north_w
 EASTERN_DIRECTIONS   = [Direction.north_east, Direction.east,  Direction.south_east]
 SOUTHERN_DIRECTIONS  = [Direction.south_east, Direction.south, Direction.south_west]
 WESTERN_DIRECTIONS   = [Direction.south_west, Direction.west,  Direction.north_west]
+DIAGONAL_DIRECTIONS  = [Direction.north_east, Direction.north_west, Direction.south_east, Direction.south_west]
 ALL_DIRECTIONS = [Direction.north, Direction.north_east,
                     Direction.east,  Direction.south_east,
                     Direction.south, Direction.south_west,
@@ -40,15 +41,25 @@ class TestNeighbourGraph (unittest.TestCase):
         # 1x(0.5+0.5)
         # global
         
-        self.ng_dict_3x3 = {"1": {1: [ ], 2: [2], 3: [5], 4: [4], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
-                            "2": {1: [ ], 2: [3], 3: [6], 4: [5], -1: [4], -2: [1], -3: [ ], -4: [ ]},
-                            "3": {1: [ ], 2: [ ], 3: [ ], 4: [6], -1: [5], -2: [2], -3: [ ], -4: [ ]},
-                            "4": {1: [2], 2: [5], 3: [8], 4: [7], -1: [ ], -2: [ ], -3: [ ], -4: [1]},
-                            "5": {1: [3], 2: [6], 3: [9], 4: [8], -1: [7], -2: [4], -3: [1], -4: [2]},
-                            "6": {1: [ ], 2: [ ], 3: [ ], 4: [9], -1: [8], -2: [5], -3: [2], -4: [3]},
-                            "7": {1: [5], 2: [8], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [4]},
-                            "8": {1: [6], 2: [9], 3: [ ], 4: [ ], -1: [ ], -2: [7], -3: [4], -4: [5]},
-                            "9": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [8], -3: [5], -4: [6]}}
+        self.ng_dict_3x3 = {1: {1: [ ], 2: [2], 3: [5], 4: [4], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                            2: {1: [ ], 2: [3], 3: [6], 4: [5], -1: [4], -2: [1], -3: [ ], -4: [ ]},
+                            3: {1: [ ], 2: [ ], 3: [ ], 4: [6], -1: [5], -2: [2], -3: [ ], -4: [ ]},
+                            4: {1: [2], 2: [5], 3: [8], 4: [7], -1: [ ], -2: [ ], -3: [ ], -4: [1]},
+                            5: {1: [3], 2: [6], 3: [9], 4: [8], -1: [7], -2: [4], -3: [1], -4: [2]},
+                            6: {1: [ ], 2: [ ], 3: [ ], 4: [9], -1: [8], -2: [5], -3: [2], -4: [3]},
+                            7: {1: [5], 2: [8], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [4]},
+                            8: {1: [6], 2: [9], 3: [ ], 4: [ ], -1: [ ], -2: [7], -3: [4], -4: [5]},
+                            9: {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [8], -3: [5], -4: [6]}}
+
+        # self.ng_dict_3x3 = {1: {"1": [ ], "2": [2], "3": [5], "4": [4], "-1": [ ], "-2": [ ], "-3": [ ], "-4": [ ]},
+        #                     2: {"1": [ ], "2": [3], "3": [6], "4": [5], "-1": [4], "-2": [1], "-3": [ ], "-4": [ ]},
+        #                     3: {"1": [ ], "2": [ ], "3": [ ], "4": [6], "-1": [5], "-2": [2], "-3": [ ], "-4": [ ]},
+        #                     4: {"1": [2], "2": [5], "3": [8], "4": [7], "-1": [ ], "-2": [ ], "-3": [ ], "-4": [1]},
+        #                     5: {"1": [3], "2": [6], "3": [9], "4": [8], "-1": [7], "-2": [4], "-3": [1], "-4": [2]},
+        #                     6: {"1": [ ], "2": [ ], "3": [ ], "4": [9], "-1": [8], "-2": [5], "-3": [2], "-4": [3]},
+        #                     7: {"1": [5], "2": [8], "3": [ ], "4": [ ], "-1": [ ], "-2": [ ], "-3": [ ], "-4": [4]},
+        #                     8: {"1": [6], "2": [9], "3": [ ], "4": [ ], "-1": [ ], "-2": [7], "-3": [4], "-4": [5]},
+        #                     9: {"1": [ ], "2": [ ], "3": [ ], "4": [ ], "-1": [ ], "-2": [8], "-3": [5], "-4": [6]}}
         
         # Non-global 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
         self.arbitrary_neighbour_graph = create_ng_from_dict(self.ng_dict_3x3)
@@ -65,7 +76,6 @@ class TestNeighbourGraph (unittest.TestCase):
         self.assertIsInstance(ng, NeighbourGraph)
         self.assertEqual(ng.neighbour_graph, self.ng_dict_3x3)
 
-    
     def test_increment_ids(self):
         
         increment = 10
@@ -83,7 +93,6 @@ class TestNeighbourGraph (unittest.TestCase):
         
         self.assertEqual(ng.get_graph(), manually_incremented_ng.get_graph())
 
-    
     def test_get_graph(self):
         
         ng_dict = self.arbitrary_neighbour_graph.get_graph()
@@ -91,7 +100,7 @@ class TestNeighbourGraph (unittest.TestCase):
     
     def test_update_neighbour(self):
         
-        node_to_update = "1"
+        node_to_update = 1
         direction_to_update = 1
         updated_neighbours = [1,2,3,4,5]
 
@@ -104,7 +113,7 @@ class TestNeighbourGraph (unittest.TestCase):
         self.assertEqual(ng.get_graph(), manually_updated_ng)
     
     def test_add_neighbour(self):
-        node_to_update = "1"
+        node_to_update = 1
         direction_to_update = 1
         neighbour_to_add = 123
 
@@ -141,6 +150,7 @@ class TestNeighbourGraph (unittest.TestCase):
 
         for cb_index in self.ng_dict_3x3.keys():
             for direction in dir_obj.__dict__.values():
+                direction = direction
                 ng_neighbours = self.arbitrary_neighbour_graph.get_neighbours(cb_index, direction)
                 self.assertEqual(ng_neighbours, self.ng_dict_3x3[cb_index][direction])
     
@@ -159,7 +169,7 @@ class TestNeighbourGraph (unittest.TestCase):
     
     def test_remove_node(self):
 
-        index_to_remove = '5'
+        index_to_remove = 5
         ng = create_ng_from_dict(self.ng_dict_3x3)
         ng.remove_node(index_to_remove)
 
@@ -177,8 +187,25 @@ class TestNeighbourGraph (unittest.TestCase):
         raise NotImplementedError
     
     def test_update_corner_neighbours(self):
-        raise NotImplementedError
-    
+
+        # Arbitrary values that don't alreayd appear in NG
+        nw_idx = 111
+        ne_idx = 222
+        sw_idx = 333
+        se_idx = 444
+
+        base_cb_idx = 5
+        # Create new neighbourgraph to avoid editing base copy
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        # Create updated graph with arbitrary values above
+        ng.update_corner_neighbours(base_cb_idx,nw_idx, ne_idx, sw_idx, se_idx)
+
+        # Test to see if the corner values were updated
+        self.assertEqual(ng.neighbour_graph[1][-Direction.north_west], [nw_idx])
+        self.assertEqual(ng.neighbour_graph[3][-Direction.north_east], [ne_idx])
+        self.assertEqual(ng.neighbour_graph[7][-Direction.south_west], [sw_idx])
+        self.assertEqual(ng.neighbour_graph[9][-Direction.south_east], [se_idx])
+        
     def test_get_neighbour_case_bounds(self):
 
         # Set base boundary
@@ -369,7 +396,7 @@ class TestNeighbourGraph (unittest.TestCase):
     def test_get_neighbour_map(self):
         ng = create_ng_from_dict(self.ng_dict_3x3)
 
-        self.assertEqual(ng.get_neighbour_map("1"), self.ng_dict_3x3["1"])
+        self.assertEqual(ng.get_neighbour_map(1), self.ng_dict_3x3[1])
 
 
 

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -1,5 +1,6 @@
 
 import unittest
+import copy
 from meshiphi.mesh_generation.direction import Direction
 from meshiphi.mesh_generation.neighbour_graph import NeighbourGraph
 from meshiphi.mesh_generation.metadata import Metadata
@@ -7,6 +8,15 @@ from meshiphi.dataloaders.factory import DataLoaderFactory
 from meshiphi.mesh_generation.cellbox import CellBox
 
 from meshiphi.mesh_generation.boundary import Boundary
+
+
+def create_ng_from_dict(ng_dict, global_mesh=False):
+    ng = NeighbourGraph()
+    ng.neighbour_graph = copy.deepcopy(ng_dict)
+    ng._is_global_mesh = global_mesh
+
+    return ng
+
 class TestNeighbourGraph (unittest.TestCase):
     
     def setUp(self):
@@ -18,54 +28,140 @@ class TestNeighbourGraph (unittest.TestCase):
         # 1x(0.5+0.5)
         # global
         
-        # 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
-        self.arbitrary_neighbour_graph =  {"1": {1: [ ], 2: [ ], 3: [5], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
-                                           "2": {1: [ ], 2: [ ], 3: [ ], 4: [5], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
-                                           "3": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [5], -2: [ ], -3: [ ], -4: [ ]},
-                                           "4": {1: [ ], 2: [5], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
-                                           "5": {1: [3], 2: [6], 3: [9], 4: [8], -1: [7], -2: [4], -3: [1], -4: [2]},
-                                           "6": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [5], -3: [ ], -4: [ ]},
-                                           "7": {1: [5], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
-                                           "8": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [5]},
-                                           "9": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [5], -4: [ ]}}
+        self.ng_dict_3x3 = {"1": {1: [ ], 2: [2], 3: [5], 4: [4], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                            "2": {1: [ ], 2: [3], 3: [6], 4: [5], -1: [4], -2: [1], -3: [ ], -4: [ ]},
+                            "3": {1: [ ], 2: [ ], 3: [ ], 4: [6], -1: [5], -2: [2], -3: [ ], -4: [ ]},
+                            "4": {1: [2], 2: [5], 3: [8], 4: [7], -1: [ ], -2: [ ], -3: [ ], -4: [1]},
+                            "5": {1: [3], 2: [6], 3: [9], 4: [8], -1: [7], -2: [4], -3: [1], -4: [2]},
+                            "6": {1: [ ], 2: [ ], 3: [ ], 4: [9], -1: [8], -2: [5], -3: [2], -4: [3]},
+                            "7": {1: [5], 2: [8], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [4]},
+                            "8": {1: [6], 2: [9], 3: [ ], 4: [ ], -1: [ ], -2: [7], -3: [4], -4: [5]},
+                            "9": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [8], -3: [5], -4: [6]}}
+        
+        # Non-global 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
+        self.arbitrary_neighbour_graph = create_ng_from_dict(self.ng_dict_3x3)
         
         # 1x2 Neighbour graph, oriented E-W
         self.antimeridian_neighbour_graph = {"1":{1: [ ], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
                                              "2":{1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [1], -3: [ ], -4: [ ]}}
 
-        raise NotImplementedError
 
     def test_from_json(self):
-        raise NotImplementedError
+
+        ng = NeighbourGraph.from_json(self.ng_dict_3x3)
+
+        self.assertIsInstance(ng, NeighbourGraph)
+        self.assertEqual(ng.neighbour_graph, self.ng_dict_3x3)
+
     
     def test_increment_ids(self):
-        raise NotImplementedError
+        
+        increment = 10
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        ng.increment_ids(10)
+        
+        # Add 'increment' to nodes and neighbours stored within the neighbourgraph dict
+        # Creates a dict of form {str(node + increment): {direction: [neighbours + increment]}}
+        manually_incremented_dict = {
+            str(int(node) + increment): {direction: [neighbour + increment for neighbour in neighbours] 
+                                        for direction, neighbours in dir_map.items() 
+            } for node, dir_map in self.ng_dict_3x3.items()
+        }
+        manually_incremented_ng = create_ng_from_dict(manually_incremented_dict)
+        
+        self.assertEqual(ng.get_graph(), manually_incremented_ng.get_graph())
+
     
     def test_get_graph(self):
-        raise NotImplementedError
+        
+        ng_dict = self.arbitrary_neighbour_graph.get_graph()
+        self.assertEqual(ng_dict, self.ng_dict_3x3)
     
     def test_update_neighbour(self):
-        raise NotImplementedError
+        
+        node_to_update = "1"
+        direction_to_update = 1
+        updated_neighbours = [1,2,3,4,5]
+
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        ng.update_neighbour(node_to_update, direction_to_update, updated_neighbours)
+
+        manually_updated_ng = copy.deepcopy(self.ng_dict_3x3)
+        manually_updated_ng[node_to_update][direction_to_update] = updated_neighbours
+
+        self.assertEqual(ng.get_graph(), manually_updated_ng)
     
     def test_add_neighbour(self):
-        raise NotImplementedError
+        node_to_update = "1"
+        direction_to_update = 1
+        neighbour_to_add = 123
+
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        ng.add_neighbour(node_to_update, direction_to_update, neighbour_to_add)
+
+        manually_added_ng_dict = copy.deepcopy(self.ng_dict_3x3)
+        manually_added_ng_dict[node_to_update][direction_to_update].append(neighbour_to_add)
+
+        self.assertEqual(ng.get_graph(), manually_added_ng_dict)
     
     def test_remove_node_and_update_neighbours(self):
+        
+        # node_to_remove = '5'
+
+        # ng = create_ng_from_dict(self.ng_dict_3x3)
+        # ng.remove_node_and_update_neighbours(node_to_remove)
+        
+        # manually_removed_ng_dict = copy.deepcopy(self.ng_dict_3x3)
+        # for node, dir_map in manually_removed_ng_dict.items():
+        #     for direction in dir_map.keys():
+        #         if node_to_remove in node[direction]:
+        #             node[direction].pop(node_to_remove)
+        # manually_removed_ng_dict.pop(node_to_remove)
+
+        # self.assertEqual(ng.get_graph(), manually_removed_ng_dict)
+
+
+        ## I think there's a bug in remove_node_in_neighbours
         raise NotImplementedError
     
     def test_get_neighbours(self):
-        raise NotImplementedError
+        dir_obj = Direction()
+
+        for cb_index in self.ng_dict_3x3.keys():
+            for direction in dir_obj.__dict__.values():
+                ng_neighbours = self.arbitrary_neighbour_graph.get_neighbours(cb_index, direction)
+                self.assertEqual(ng_neighbours, self.ng_dict_3x3[cb_index][direction])
     
     def test_add_node(self):
-        raise NotImplementedError
+
+        index_to_add = '999'
+        neighbour_map_to_add = {1: [123], 2: [234], 3: [345], 4: [456], -1: [567], -2: [678], -3: [789], -4: [890]}
+
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        ng.add_node(index_to_add, neighbour_map_to_add)
+
+        manually_added_ng_dict = copy.deepcopy(self.ng_dict_3x3)
+        manually_added_ng_dict[index_to_add] = neighbour_map_to_add
+
+        self.assertEqual(ng.get_graph(), manually_added_ng_dict)
     
     def test_remove_node(self):
-        raise NotImplementedError
+
+        index_to_remove = '5'
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+        ng.remove_node(index_to_remove)
+
+        manually_removed_ng_dict = copy.deepcopy(self.ng_dict_3x3)
+        manually_removed_ng_dict.pop(index_to_remove)
+
+        self.assertEqual(ng.get_graph(), manually_removed_ng_dict)
     
     def test_update_neighbours(self):
+        ## I think there's a bug in remove_node_in_neighbours
         raise NotImplementedError
     
     def test_remove_node_from_neighbours(self):
+        ## I think there's a bug in remove_node_in_neighbours
         raise NotImplementedError
     
     def test_update_corner_neighbours(self):
@@ -90,13 +186,23 @@ class TestNeighbourGraph (unittest.TestCase):
         raise NotImplementedError
     
     def test_set_global_mesh(self):
-        raise NotImplementedError
-    
+        global_ng = create_ng_from_dict(self.ng_dict_3x3,    global_mesh=True)
+        nonglobal_ng = create_ng_from_dict(self.ng_dict_3x3, global_mesh=False)
+
+        self.assertTrue(global_ng._is_global_mesh)
+        self.assertFalse(nonglobal_ng._is_global_mesh)
+
     def test_is_global_mesh(self):
-        raise NotImplementedError
+        global_ng = create_ng_from_dict(self.ng_dict_3x3,    global_mesh=True)
+        nonglobal_ng = create_ng_from_dict(self.ng_dict_3x3, global_mesh=False)
+
+        self.assertTrue(global_ng.is_global_mesh())
+        self.assertFalse(nonglobal_ng.is_global_mesh())
     
     def test_get_neighbour_map(self):
-        raise NotImplementedError
+        ng = create_ng_from_dict(self.ng_dict_3x3)
+
+        self.assertEqual(ng.get_neighbour_map("1"), self.ng_dict_3x3["1"])
 
 
 

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -34,13 +34,7 @@ class TestNeighbourGraph (unittest.TestCase):
     
     def setUp(self):
         
-        # Cases to account for
-        # 3x3 grid
-        # 1x2
-        # 1x2 on antimeridian
-        # 1x(0.5+0.5)
-        # global
-        
+        # Neighbour graph of a 3x3 array of cellboxes        
         self.ng_dict_3x3 = {1: {1: [ ], 2: [2], 3: [5], 4: [4], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
                             2: {1: [ ], 2: [3], 3: [6], 4: [5], -1: [4], -2: [1], -3: [ ], -4: [ ]},
                             3: {1: [ ], 2: [ ], 3: [ ], 4: [6], -1: [5], -2: [2], -3: [ ], -4: [ ]},
@@ -54,10 +48,6 @@ class TestNeighbourGraph (unittest.TestCase):
         # Non-global 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
         self.neighbour_graph = create_ng_from_dict(self.ng_dict_3x3)
         
-        # 1x2 Neighbour graph, oriented E-W
-        self.antimeridian_neighbour_graph = {"1":{1: [ ], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
-                                             "2":{1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [1], -3: [ ], -4: [ ]}}
-
     def test_from_json(self):
 
         ng = NeighbourGraph.from_json(self.ng_dict_3x3)
@@ -502,7 +492,6 @@ class TestNeighbourGraph (unittest.TestCase):
 
             self.assertEqual(neighbour_map, reference_neighbour_graph[cb_idx])
             
-
     def test_set_global_mesh(self):
         global_ng = create_ng_from_dict(self.ng_dict_3x3,    global_mesh=True)
         nonglobal_ng = create_ng_from_dict(self.ng_dict_3x3, global_mesh=False)
@@ -521,80 +510,3 @@ class TestNeighbourGraph (unittest.TestCase):
         ng = create_ng_from_dict(self.ng_dict_3x3)
 
         self.assertEqual(ng.get_neighbour_map(1), self.ng_dict_3x3[1])
-
-
-
-   # def setUp(self):
-   #       boundary = Boundary([-85,-80], [-135,-130], ['1970-01-01','2021-12-31'])
-   #       cellbox = CellBox (boundary , 0)
-   #       params = {
-   #    'file': '../../datastore/bathymetry/GEBCO/gebco_2022_n-40.0_s-90.0_w-140.0_e0.0.nc',
-	# 	'downsample_factors': (5,5),
-	# 	'data_name': 'elevation',
-	# 	'aggregate_type': 'MAX',
-   #     'value_fill_types': "parent"
-   #       }
-   #       split_conds = {
-	# 'threshold': 620,
-	# 'upper_bound': 0.9,
-	# 'lower_bound': 0.1
-	# }
-        
-   #       gebco = DataLoaderFactory().get_dataloader('GEBCO', boundary , params, min_dp = 5)
-   #       cellbox.set_data_source ([Metadata (gebco , [split_conds] ,  params ['value_fill_types'])])
-   #       self.cellboxes = cellbox.split(0)
-   #       cell_width = 2.5
-   #       grid_width = (boundary.get_long_max() - boundary.get_long_min()) / cell_width
-   #       self.neighbour_graph = NeighbourGraph (self.cellboxes ,grid_width )
-         
-
-   # def test_initialize_NG(self):
-   #    self.assertEqual ( 4 , len (self.neighbour_graph.get_graph()))
-   #    self.assertEqual ( {1: [3], 2: [1], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
-   #    self.assertEqual ( {1: [], 2: [], 3: [], 4: [], -1: [], -2: [0], -3: [2], -4: [3]} , self.neighbour_graph.get_graph()[1]) # NE cellbox
-   #    self.assertEqual ( {1: [], 2: [3], 3: [1], 4: [0], -1: [], -2: [], -3: [], -4: []} , self.neighbour_graph.get_graph()[2]) # SW cellbox
-   #    self.assertEqual ( {1: [], 2: [], 3: [], 4: [1], -1: [0], -2: [2], -3: [], -4: []} , self.neighbour_graph.get_graph()[3]) # SE cellbox
-
-   
-   # def test_remove_neighbour (self):
-   #    self.neighbour_graph.remove_neighbour(0 ,  Direction.east , 1)
-   #    self.assertEqual ( {1: [3], 2: [], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
-   #    self.neighbour_graph.update_neighbour(0 , Direction.east , [1]) # undo the remove
-
-   # def test_update_neighbour (self):
-   #    self.neighbour_graph.update_neighbour(0 ,  Direction.south_east , [3])
-   #    self.assertEqual ( {1: [3], 2: [1], 3: [3], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # NW cellbox
-   #    self.neighbour_graph.remove_neighbour(0 ,  Direction.south_east , 3)# undo the update
-  
-   # def test_get_neighbour_case(self):
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[1])
-   #    self.assertEqual ( 2, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[2])
-   #    self.assertEqual ( 4, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[0] , self.cellboxes[3])
-   #    self.assertEqual (3 , case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[2] , self.cellboxes[0])
-   #    self.assertEqual ( -4, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[1] , self.cellboxes[2])
-   #    self.assertEqual ( -1, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[2] , self.cellboxes[1])
-   #    self.assertEqual ( 1, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[0])
-   #    self.assertEqual ( -3, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[2])
-   #    self.assertEqual ( -2, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[3] , self.cellboxes[1])
-   #    self.assertEqual ( -4, case)
-   #    case = self.neighbour_graph.get_neighbour_case(self.cellboxes[1] , self.cellboxes[3])
-   #    self.assertEqual ( 4, case)
-
-   # def test_update_neighbours (self):
-   #    self.neighbour_graph.update_neighbours(0, [2,1], Direction.north_east, self.cellboxes)
-   #    self.assertEqual (  {1: [], 2: [], 3: [], 4: [1], -1: [], -2: [2,2], -3: [], -4: [1]} , self.neighbour_graph.get_graph()[3]) # SE cellbox
-   #    self.neighbour_graph.update_neighbour(3, Direction.south, [1]) # undo the first update 
-   #    self.neighbour_graph.update_neighbour(3, Direction.west, [2]) # undo the first update 
-   #    self.neighbour_graph.update_neighbour(3, Direction.north, []) # undo the first update 
-  
-   # def test_update_corner_neighbours(self):
-   #    self.neighbour_graph.update_corner_neighbours (3 , -1, -1, -1, -1 )
-   #    self.assertEqual ( {1: [-1], 2: [1], 3: [], 4: [], -1: [], -2: [], -3: [], -4: [2]} , self.neighbour_graph.get_graph()[0]) # SE cellbox

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -1,12 +1,10 @@
 
 import unittest
 import copy
+
 from meshiphi.mesh_generation.direction import Direction
 from meshiphi.mesh_generation.neighbour_graph import NeighbourGraph
-from meshiphi.mesh_generation.metadata import Metadata
-from meshiphi.dataloaders.factory import DataLoaderFactory
 from meshiphi.mesh_generation.cellbox import CellBox
-
 from meshiphi.mesh_generation.boundary import Boundary
 from meshiphi.utils import longitude_domain
 

--- a/tests/unit_tests/test_neighbour_graph.py
+++ b/tests/unit_tests/test_neighbour_graph.py
@@ -10,7 +10,30 @@ from meshiphi.mesh_generation.boundary import Boundary
 class TestNeighbourGraph (unittest.TestCase):
     
     def setUp(self):
-        pass
+        
+        # Cases to account for
+        # 3x3 grid
+        # 1x2
+        # 1x2 on antimeridian
+        # 1x(0.5+0.5)
+        # global
+        
+        # 3x3 Neighbour graph, "5" in the middle, with the others all surrounding it
+        self.arbitrary_neighbour_graph =  {"1": {1: [ ], 2: [ ], 3: [5], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                                           "2": {1: [ ], 2: [ ], 3: [ ], 4: [5], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                                           "3": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [5], -2: [ ], -3: [ ], -4: [ ]},
+                                           "4": {1: [ ], 2: [5], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                                           "5": {1: [3], 2: [6], 3: [9], 4: [8], -1: [7], -2: [4], -3: [1], -4: [2]},
+                                           "6": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [5], -3: [ ], -4: [ ]},
+                                           "7": {1: [5], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                                           "8": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [5]},
+                                           "9": {1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [5], -4: [ ]}}
+        
+        # 1x2 Neighbour graph, oriented E-W
+        self.antimeridian_neighbour_graph = {"1":{1: [ ], 2: [2], 3: [ ], 4: [ ], -1: [ ], -2: [ ], -3: [ ], -4: [ ]},
+                                             "2":{1: [ ], 2: [ ], 3: [ ], 4: [ ], -1: [ ], -2: [1], -3: [ ], -4: [ ]}}
+
+        raise NotImplementedError
 
     def test_from_json(self):
         raise NotImplementedError


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-06-19
Version Number: 2.1.11
 
## Description of change
Added unit tests for neighbour_graph.py

There is a bug in `test_get_global_mesh_neighbour_case()` that realistically won't ever get called, but exists nonetheless.
As such, not all tests pass in this PR. I can fix this up before merging if requested, just note that it will mean that the test and the source file will both change in the same PR. 


# Testing

- [ ] My changes have not altered any of the files listed in the testing strategy

- [ ] My changes result in all required regression tests passing without the need to update test files.  

- [x] My changes require one or more test files to be updated for all ~~regression~~ **unit** tests to pass.   
[One failing test](https://github.com/user-attachments/files/15898102/test_neighbour_graph.log)


# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [x] My PR has been made to the `2.1.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  