### PR TITLE
Hom condition hotfix

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.12"
+__version__ = "2.1.13"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/meshiphi/dataloaders/scalar/abstract_scalar.py
+++ b/meshiphi/dataloaders/scalar/abstract_scalar.py
@@ -560,7 +560,11 @@ class ScalarDataLoader(DataLoaderInterface):
             else:
                 # Determine fraction of datapoints over threshold value
                 num_over_threshold = np.count_nonzero(dps > splitting_conds['threshold'])
-                frac_over_threshold = num_over_threshold/dps.size
+                num_non_nan = np.count_nonzero(~np.isnan(dps))
+                if num_non_nan > 0:
+                    frac_over_threshold = num_over_threshold/num_non_nan
+                else:
+                    frac_over_threshold = 0
                 # Return homogeneity condition
                 if   frac_over_threshold <= splitting_conds['lower_bound']: hom_type = "CLR"
                 elif frac_over_threshold >= splitting_conds['upper_bound']: 

--- a/meshiphi/dataloaders/scalar/abstract_scalar.py
+++ b/meshiphi/dataloaders/scalar/abstract_scalar.py
@@ -524,7 +524,11 @@ class ScalarDataLoader(DataLoaderInterface):
             else:
                 # Determine fraction of datapoints over threshold value
                 num_over_threshold = dps[dps > splitting_conds['threshold']]
-                frac_over_threshold = num_over_threshold.shape[0]/dps.shape[0]
+                num_non_nan = np.count_nonzero(~np.isnan(dps))
+                if num_non_nan > 0:
+                    frac_over_threshold = num_over_threshold.shape[0]/num_non_nan
+                else:
+                    frac_over_threshold = 0
 
                 # Return homogeneity condition
                 if   frac_over_threshold <= splitting_conds['lower_bound']: hom_type = "CLR"

--- a/meshiphi/dataloaders/vector/abstract_vector.py
+++ b/meshiphi/dataloaders/vector/abstract_vector.py
@@ -571,6 +571,9 @@ class VectorDataLoader(DataLoaderInterface):
                 flow = self.calc_dmag(bounds, collapse=False)
                 sc = splitting_conds['dmag']
 
+            if 'split_lock' not in sc:
+                sc['split_lock'] = False
+
             if isinstance(flow, type(np.nan)) and np.isnan(flow):
                 return "CLR"
             num_over_threshold = (flow > sc['threshold']).sum()
@@ -585,7 +588,7 @@ class VectorDataLoader(DataLoaderInterface):
             if   frac_over_threshold <= sc['lower_bound']: 
                 hom_type = "CLR"
             elif frac_over_threshold >= sc['upper_bound']:
-                if splitting_conds['split_lock'] == True:
+                if sc['split_lock'] == True:
                     hom_type = "HOM"
                 else: 
                     hom_type = "CLR"

--- a/meshiphi/dataloaders/vector/abstract_vector.py
+++ b/meshiphi/dataloaders/vector/abstract_vector.py
@@ -574,7 +574,13 @@ class VectorDataLoader(DataLoaderInterface):
             if isinstance(flow, type(np.nan)) and np.isnan(flow):
                 return "CLR"
             num_over_threshold = (flow > sc['threshold']).sum()
-            frac_over_threshold = num_over_threshold / flow.size
+            
+            num_non_nan = np.count_nonzero(~np.isnan(flow))
+            if num_non_nan > 0:
+                frac_over_threshold = num_over_threshold/num_non_nan
+            else:
+                frac_over_threshold = 0
+
 
             if   frac_over_threshold <= sc['lower_bound']: 
                 hom_type = "CLR"


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-09-19
Version Number: 2.1.13

## Description of change
Fixes bug where NaNs were being counted towards the frac_above_threshold value when calculating the homogeneity condition, causing unnecessary splitting in cases where input data is largely NaN and the upper/lower bounds weren't loose enough to compensate. 

Also brings the splitting condition format for vector dataloaders more towards parity with the scalar dataloaders than they were. Previously, splitting conditions for vector data always split above a threshold, and never split below it, which effectively meant that the upper/lower bounds were 0/0. Now they accept upper/lower bounds like the scalar dataloader. 

This means that the Reynolds splitting had to be deprecated, as it cannot be calculated as a proportion of each cellbox. Given that it wasn't being used operationally anyway, this should have no real impact. Divergence was also deprecated for this reason. 

## Fixes #78

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [x] My changes have not altered any of the files listed in the testing strategy
[Passing reg tests anyway](https://github.com/user-attachments/files/17058555/pytest_output.txt)

- [ ] My changes result in all required regression tests passing without the need to update test files.  
  
- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [ ] My PR has been made to the `2.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
