### PR TITLE
Split loc(k) hotfix

### DIFF
--- a/meshiphi/__init__.py
+++ b/meshiphi/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "2.1.14"
+__version__ = "2.1.15"
 __description__ = "MeshiPhi: Earth's digital twin mapped on a non-uniform mesh"
 __license__ = "MIT"
 __author__ = "Autonomous Marine Operations Planning (AMOP) Team, AI Lab, British Antarctic Survey"

--- a/meshiphi/dataloaders/lut/abstract_lut.py
+++ b/meshiphi/dataloaders/lut/abstract_lut.py
@@ -334,17 +334,18 @@ class LutDataLoader(DataLoaderInterface):
         # Extract polygons that overlap the boundary
         polygons = self.trim_datapoints(bounds, data=data)['geometry'].tolist()
         
-    
+        hom_type = 'CLR'
         # If there's no polygon that overlaps with bounds        
         if not any([polygon.intersects(bounds_polygon) for polygon in polygons]):
-            return 'CLR'
+            if splitting_conds['split_lock'] == True: 
+                hom_type = "HOM"
         # If we want to split on the boundary
         elif splitting_conds['boundary']:
             if any(p.boundary.intersects(bounds_polygon) for p in polygons):
-                return 'HET'
+                hom_type = 'HET'
             
         # Otherwise no boundaries intersected bounds
-        return 'CLR'
+        return hom_type
 
     def reproject(self):
         '''

--- a/meshiphi/mesh_generation/environment_mesh.py
+++ b/meshiphi/mesh_generation/environment_mesh.py
@@ -171,7 +171,7 @@ class EnvironmentMesh:
         cb_width  = agg_cellbox_wp.boundary.get_width()
         cb_height = agg_cellbox_wp.boundary.get_height()
 
-        if (cb_width < min_dcx) or (cb_height < min_dcy):
+        if (cb_width <= min_dcx) or (cb_height <= min_dcy):
             # Continue if cellbox is at max split depth
             return False
         else:


### PR DESCRIPTION
# MeshiPhi Pull Request Template

Date: 2024-11-05
Version Number: 2.1.15
 
## Description of change
- Change to make split_loc stop at max split depth defined in original mesh config. Current behaviour on main is to split one level further than necessary.

- Added split_lock option for LUT dataloaders. This was just an oversight from when split_lock was first implemented, and we never tried to do it on a LUT dataloader before.

## Fixes  #83 

# Testing
To ensure that the functionality of the MeshiPhi codebase remains consistent throughout the development cycle a testing strategy has been developed, which can be viewed in the document `test/testing_strategy.md`. 
This includes a collection of test files which should be run according to which part of the codebase has been altered in a pull request. Please consult the testing strategy to determine which tests need to be run. 

- [ ] My changes have not altered any of the files listed in the testing strategy

- [x] My changes result in all required regression tests passing without the need to update test files.  

- [ ] My changes require one or more test files to be updated for all regression tests to pass.   

# Checklist

- [x] My code follows [pep8](https://peps.python.org/pep-0008/) style guidelines.  
- [x] I have commented my code, particularly in hard-to-understand areas.  
- [x] I have updated the documentation of the codebase where required.  
- [x] My changes generate no new warnings.   
- [ ] My PR has been made to the `2.2.x` branch (**DO NOT SUBMIT A PR TO MAIN**)  

   
