### PR TITLE
fix import error and use minimal example to speed up tif writing test

### DIFF
--- a/meshiphi/mesh_generation/environment_mesh.py
+++ b/meshiphi/mesh_generation/environment_mesh.py
@@ -1379,7 +1379,10 @@ class EnvironmentMesh:
                      os.remove(file_path)
 
         # Only import if we need GDAL, to avoid having it as a requirement
-        from osgeo import gdal, ogr, osr
+        try:
+            from osgeo import gdal, ogr, osr
+        except ImportError:
+            raise ImportError("GDAL is required for tif export. Install with: conda install -c conda-forge gdal")
         
         params = {}
         params = load_params(params_file)

--- a/tests/unit_tests/test_env_mesh.py
+++ b/tests/unit_tests/test_env_mesh.py
@@ -5,6 +5,9 @@ from pathlib import Path
 import tempfile
 from meshiphi.mesh_generation.environment_mesh import EnvironmentMesh
 from meshiphi.mesh_generation.mesh_builder import MeshBuilder
+from meshiphi.mesh_generation.boundary import Boundary
+from meshiphi.mesh_generation.aggregated_cellbox import AggregatedCellBox
+from meshiphi.mesh_generation.neighbour_graph import NeighbourGraph
 
 
 class TestEnvMesh(unittest.TestCase):
@@ -32,22 +35,52 @@ class TestEnvMesh(unittest.TestCase):
         self.assertEqual(self.loaded_env_mesh.agg_cellboxes[0].get_agg_data()["x"], "5")
 
     def test_to_tif(self):
-        test_dir = Path(__file__).parent.parent
-        mesh_file = test_dir / "regression_tests/example_meshes/env_meshes/grf_reprojection.json"
-        vessel_mesh = None
-        with open(mesh_file, "r") as config_file:
-            vessel_file = json.load(config_file)
-        env_mesh = EnvironmentMesh.load_from_json(vessel_file)
+        """Test GDAL import and basic tif functionality without full mesh processing"""
+        # Test that GDAL imports work
+        try:
+            from osgeo import gdal
+        # The reason for doing this is that GDAL is an optional dependency, and only used for
+        # exporting to tif. If GDAL is not installed, we skip this test.
+        except ImportError:
+            self.skipTest("GDAL not available - install with: conda install -c conda-forge gdal")
         
-        # Use a temporary file for the test
+        # Create a simple test mesh with minimal data
+        # Boundary constructor takes (lat_range, long_range, time_range=None)
+        lat_range = [-10, -5]
+        long_range = [10, 15]
+        bounds = Boundary(lat_range, long_range)
+        
+        # Again, minimal boxes, graph and config
+        cellbox = AggregatedCellBox(bounds, {"test_value": 1.5}, "test_cellbox_0")
+        agg_cellboxes = [cellbox]
+        neighbour_graph = NeighbourGraph()
+        config = {"test": True}
+        
+        env_mesh = EnvironmentMesh(bounds, agg_cellboxes, neighbour_graph, config)
+        
+        # Test tif export with temporary file
         with tempfile.NamedTemporaryFile(suffix=".tif", delete=False) as tmp:
             tmp_path = tmp.name
         
+        # Create format parameters for tif export
+        with tempfile.NamedTemporaryFile(mode='w', suffix=".json", delete=False) as params_file:
+            format_params = {
+                "data_name": "test_value",
+                "sampling_resolution": [10, 10],  # Small resolution for faster test
+                "projection": "4326"
+            }
+            json.dump(format_params, params_file)
+            params_path = params_file.name
+        
         try:
-            env_mesh.save(tmp_path, format="tif")
+            env_mesh.save(tmp_path, format="tif", format_params=params_path)
             # Verify the file was created
             self.assertTrue(os.path.exists(tmp_path))
+            # Verify it's a valid tiff file
+            self.assertGreater(os.path.getsize(tmp_path), 0)
         finally:
             # Clean up
             if os.path.exists(tmp_path):
                 os.remove(tmp_path)
+            if os.path.exists(params_path):
+                os.remove(params_path)


### PR DESCRIPTION
Closes #99 

Fixing the `gdal` import error when not installed - it is an optional dependency, so skipping the test.

Also massively speeding up the test itself by using a very minimal mesh, rather than actual mesh file. All we're testing is that it has written to .tif, we do not need the actual mesh. 